### PR TITLE
Add generateKeyframe() API

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       extends that interface by adding an additional method.
     </p>
     <pre class="idl">partial interface RTCRtpSender {
-      Promise&lt;unsigned long> generateKeyFrame();
+      Promise&lt;unsigned long> generateKeyFrame(optional sequence &lt;DOMString> rids);
       };</pre>
     <section>
       <h2>Methods</h2>
@@ -425,10 +425,14 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
               <li>
                 Return  <var>p</var>, and let it be the result of
                 [= chaining =] the following steps to
-                    <var>connection</var>'s [= operations chain =].
+                <var>connection</var>'s [= operations chain =].
               </li>
               <li>If the sender's 'kind' is not "video", reject <var>p</var>
                 with {{NotAllowedError}}.
+              </li>
+              <li>If the <code>rids</code> argument is provided, check whether
+                  each of the RID values in the sequence are valid. If any RID
+                  values are invalid, reject <var>p</var> with {{NotAllowedError}}.
               </li>
               <li>
                 If the sender's track is not set, if the track is ended,
@@ -436,15 +440,19 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
                 {{InvalidStateError}}.
               </li>
               <li>
-                Instruct the encoder of the track to produce a keyframe.
+                If the <code>rids</code> argument is provided, instruct the
+                encoder of the track to generate keyframe(s) for each of the
+                simulcast streams represented by <code>rids</code>. If
+                <code>rids</code> is not provided, generate keyframe(s) for
+                every simulcast stream.
               </li>
               <li>
-                If the production of a keyframe fails, reject <var>p</var>
+                If generating keyframe(s) fails, reject <var>p</var>
                 with {{OperationError}}.
               <li>
-                When the encoder has produced a keyframe, and it has been
-                assigned an RTP timestamp, resolve <var>p</var> with this
-                timestamp.
+                When the encoder has generated keyframe(s) and has
+                assigned an RTP timestamp, resolve <var>p</var> with
+                the timestamp.
               </li>
             </ul>
           </dd>
@@ -462,7 +470,6 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       </pre>
     </p>
   </section>
-
   <section id="rtcrtpreceiver-interface">
     <h3>
       {{RTCRtpReceiver}} extensions

--- a/index.html
+++ b/index.html
@@ -392,6 +392,77 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       with an InvalidModificationError.
     </p>
   </section>
+  <section id="recrtpsender-interface">
+    <h3>
+      {{RTCRtpSender}} extensions
+    </h3>
+    <p>
+      The {{RTCRtpSender}} interface is defined in [[WEBRTC]]. This document
+      extends that interface by adding an additional method.
+    </p>
+    <pre class="idl">partial interface RTCRtpSender {
+      Promise&lt;unsigned long> requestKeyFrame();
+      };</pre>
+    <section>
+      <h2>Methods</h2>
+      <p>
+        <dl data-link-for="RTCRtpSender" class="methods">
+          <dt>
+            <dfn data-idl><code>requestKeyFrame</code></dfn></dt>
+          <dd>
+            <p>
+              Requests a keyframe. When called, the UA MUST perform
+              the following steps:
+            </p>
+            <ul>
+              <li>
+                Let <var>p</var> be a new promise.
+              </li>
+              <li>
+                Let <var>connection</var> be the sender''s associated
+                {{RTCPeerConnection}}.
+              </li>
+              <li>
+                Return  <var>p</var>, and let it be the result of
+                [= chaining =] the following steps to
+                    <var>connection</var>'s [= operations chain =].
+              </li>
+              <li>If the sender''s 'kind' is not "video", reject <var>p</var>
+                with {{NotAllowedError}}.
+              </li>
+              <li>
+                If the sender''s track is not set, if the track is ended,
+                or if the track is muted, reject <var>p</var> with
+                {{InvalidStateError}}.
+              </li>
+              <li>
+                Instruct the encoder of the track to produce a keyframe.
+              </li>
+              <li>
+                If the production of a keyframe fails, reject <var>p</var>
+                with {{OperationError}}.
+              <li>
+                When the encoder has produced a keyframe, and it has been
+                assigned an RTP timestamp, resolve <var>p</var> with this
+                timestamp.
+              </li>
+            </ul>
+          </dd>
+        </dl>
+      </p>
+    </section>
+    <p>
+      This call can be emulated by making the following calls,
+      except that the outgoing RTP timestamp is not recorded, and
+      the encoder may choose to encode an extra black frame:
+      <pre>
+        let track = sender.track;
+        await sender.replaceTrack(null);
+        await sender.replaceTrack(track);
+      </pre>
+    </p>
+  </section>
+
   <section id="rtcrtpreceiver-interface">
     <h3>
       {{RTCRtpReceiver}} extensions

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
                 Let <var>p</var> be a new promise.
               </li>
               <li>
-                Let <var>connection</var> be the sender''s associated
+                Let <var>connection</var> be the sender's associated
                 {{RTCPeerConnection}}.
               </li>
               <li>

--- a/index.html
+++ b/index.html
@@ -452,9 +452,9 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       </p>
     </section>
     <p>
-      This call can be emulated by making the following calls,
-      except that the outgoing RTP timestamp is not recorded, and
-      the encoder may choose to encode an extra black frame:
+      This method can be emulated (imperfectly) with the following
+      calls. However, the outgoing RTP timestamp is not recorded,
+      and the encoder may choose to encode extra black frame(s):
       <pre>
         let track = sender.track;
         await sender.replaceTrack(null);

--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       extends that interface by adding an additional method.
     </p>
     <pre class="idl">partial interface RTCRtpSender {
-      Promise&lt;unsigned long> generateKeyFrame(optional sequence &lt;DOMString> rids);
+      Promise&lt;unsigned long> generateKeyFrame(optional sequence &lt;DOMString&gt; rids);
       };</pre>
     <section>
       <h2>Methods</h2>

--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       with an InvalidModificationError.
     </p>
   </section>
-  <section id="recrtpsender-interface">
+  <section id="rtcrtpsender-interface">
     <h3>
       {{RTCRtpSender}} extensions
     </h3>
@@ -427,11 +427,11 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
                 [= chaining =] the following steps to
                     <var>connection</var>'s [= operations chain =].
               </li>
-              <li>If the sender''s 'kind' is not "video", reject <var>p</var>
+              <li>If the sender's 'kind' is not "video", reject <var>p</var>
                 with {{NotAllowedError}}.
               </li>
               <li>
-                If the sender''s track is not set, if the track is ended,
+                If the sender's track is not set, if the track is ended,
                 or if the track is muted, reject <var>p</var> with
                 {{InvalidStateError}}.
               </li>

--- a/index.html
+++ b/index.html
@@ -401,17 +401,17 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       extends that interface by adding an additional method.
     </p>
     <pre class="idl">partial interface RTCRtpSender {
-      Promise&lt;unsigned long> requestKeyFrame();
+      Promise&lt;unsigned long> generateKeyFrame();
       };</pre>
     <section>
       <h2>Methods</h2>
       <p>
         <dl data-link-for="RTCRtpSender" class="methods">
           <dt>
-            <dfn data-idl><code>requestKeyFrame</code></dfn></dt>
+            <dfn data-idl><code>generateKeyFrame</code></dfn></dt>
           <dd>
             <p>
-              Requests a keyframe. When called, the UA MUST perform
+              Generates a keyframe. When called, the UA MUST perform
               the following steps:
             </p>
             <ul>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-extensions/issues/72

This was the simplest API I could think of.
The use of the operations chain (which I haven't been able to cite correctly) is to make it not racy with replaceTrack(), which is also on the operations chain.

I'd like to have comments from hbos and jib before proposing this to the WG.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alvestrand/webrtc-extensions/pull/37.html" title="Last updated on Nov 15, 2021, 1:39 PM UTC (7878543)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/37/c5e02da...alvestrand:7878543.html" title="Last updated on Nov 15, 2021, 1:39 PM UTC (7878543)">Diff</a>