### PR TITLE
Bring voiceActivityFlag from WebRTC 1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -950,6 +950,43 @@ enum RTCIceCredentialType {
         </p>
       </dd>
     </dl>
-  </section>
+</section>
+<section>
+    <h3>
+      {{RTCRtpSynchronizationSource}} extensions
+    </h3>
+    <p>This document extends {{RTCRtpSynchronizationSource}} with a {{RTCRtpSynchronizationSource/voiceActivityFlag}} member (initially defined in the WebRTC 1.0 specification but later dropped due to lack of implementation.</p>
+  <pre class="idl">
+    partial dictionary RTCRtpSynchronizationSource {
+    boolean voiceActivityFlag;
+    };</pre>
+              <dl data-link-for="RTCRtpSynchronizationSource" data-dfn-for=
+            "RTCRtpSynchronizationSource" class="dictionary-members">
+              <dt data-tests=
+              "RTCRtpReceiver-getSynchronizationSources.https.html">
+                <dfn data-idl="">voiceActivityFlag</dfn> of type <span class=
+                "idlMemberType">boolean</span>
+              </dt>
+              <dd>
+                <p class="needs-test">
+                  Only present for audio receivers. Whether the last RTP
+                  packet, delivered from this source, contains voice activity
+                  (true) or not (false). If the RFC 6464 extension header was
+                  not present, or if the peer has signaled that it is not using
+                  the V bit by setting the "vad" extension attribute to "off",
+                  as described in [[!RFC6464]], Section 4,
+                  {{voiceActivityFlag}} will be absent.
+                </p>
+                <div class="issue atrisk">
+                  <p>
+                    {{RTCRtpSynchronizationSource/voiceActivityFlag}} is marked
+                    as a feature at risk, since there is no clear commitment
+                    from implementers.
+                  </p>
+                </div>
+              </dd>
+            </dl>
+
+</section>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -955,7 +955,7 @@ enum RTCIceCredentialType {
     <h3>
       {{RTCRtpSynchronizationSource}} extensions
     </h3>
-    <p>This document extends {{RTCRtpSynchronizationSource}} with a {{RTCRtpSynchronizationSource/voiceActivityFlag}} member (initially defined in the WebRTC 1.0 specification but later dropped due to lack of implementation.</p>
+    <p>This document extends {{RTCRtpSynchronizationSource}} with a {{RTCRtpSynchronizationSource/voiceActivityFlag}} member (initially defined in the WebRTC 1.0 specification but later dropped due to lack of implementation).</p>
   <pre class="idl">
     partial dictionary RTCRtpSynchronizationSource {
     boolean voiceActivityFlag;

--- a/index.html
+++ b/index.html
@@ -986,7 +986,6 @@ enum RTCIceCredentialType {
                 </div>
               </dd>
             </dl>
-
 </section>
 </body>
 </html>


### PR DESCRIPTION
Removed from there in light of its 'at risk' status