### PR TITLE
Remove header extension control negotiation restriction.

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         attribute."
       </p>
       <p>
+<<<<<<< HEAD
         In the algorithm for generating subsequent offers in [[RTCWEB-JSEP]] section 5.2.2, replace "The
         RTP header extensions MUST only include those that are present in the most recent answer"
         with "For each RTP header extension listed in <a>[[\HeaderExtensionsToOffer]]</a> that is
@@ -223,6 +224,8 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         may not grow with subsequent offers.
       </p>
       <p>
+=======
+>>>>>>> e34d5f8 (Remove negotiation restriction.)
         In the algorithm for generating initial answers in [[RTCWEB-JSEP]] section 5.3.1, replace "For
         each supported RTP header extension that is present in the offer" with "For each
         supported RTP header extension that is present in the offer and is also present in

--- a/index.html
+++ b/index.html
@@ -215,10 +215,11 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       <p>
         In the algorithm for generating subsequent offers in [[RTCWEB-JSEP]] section 5.2.2, replace "The
         RTP header extensions MUST only include those that are present in the most recent answer"
-        with "For each RTP header extension listed in [[\HeaderExtensionsToOffer]], and where 
-        direction is not "stopped", generate an appropriate "a=extmap" line with "direction" set
-        according to the rules of [[RFC5285]] section 6, considering the direction in
-        [[\HeaderExtensionsToOffer]] to indicate the answerer's desired usage".
+        with "For each RTP header extension listed in <a>[[\HeaderExtensionsToOffer]]</a>,
+        and where {{RTCRtpHeaderExtensionCapability/direction}} is not {{RTCRtpTransceiverDirection/"stopped"}}, generate
+        an appropriate "a=extmap" line with "direction" set according to the rules of [[RFC5285]]
+        section 6, considering the {{RTCRtpHeaderExtensionCapability/direction}} in [[\HeaderExtensionsToOffer]] to indicate the
+        answerer's desired usage".
       </p>
       <p>
         In the algorithm for generating initial answers in [[RTCWEB-JSEP]] section 5.3.1, replace "For

--- a/index.html
+++ b/index.html
@@ -213,19 +213,14 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         attribute."
       </p>
       <p>
-<<<<<<< HEAD
         In the algorithm for generating subsequent offers in [[RTCWEB-JSEP]] section 5.2.2, replace "The
         RTP header extensions MUST only include those that are present in the most recent answer"
-        with "For each RTP header extension listed in <a>[[\HeaderExtensionsToOffer]]</a> that is
-        also present in the most recent answer, and where {{RTCRtpHeaderExtensionCapability/direction}} is not {{RTCRtpTransceiverDirection/"stopped"}}, generate
-        an appropriate "a=extmap" line with "direction" set according to the rules of [[RFC5285]]
-        section 6, considering the {{RTCRtpHeaderExtensionCapability/direction}} in [[\HeaderExtensionsToOffer]] to indicate the
-        answerer's desired usage". This preserves the property that the set of extensions
-        may not grow with subsequent offers.
+        with "For each RTP header extension listed in [[\HeaderExtensionsToOffer]], and where 
+        direction is not "stopped", generate an appropriate "a=extmap" line with "direction" set
+        according to the rules of [[RFC5285]] section 6, considering the direction in
+        [[\HeaderExtensionsToOffer]] to indicate the answerer's desired usage".
       </p>
       <p>
-=======
->>>>>>> e34d5f8 (Remove negotiation restriction.)
         In the algorithm for generating initial answers in [[RTCWEB-JSEP]] section 5.3.1, replace "For
         each supported RTP header extension that is present in the offer" with "For each
         supported RTP header extension that is present in the offer and is also present in


### PR DESCRIPTION
Fixes #60.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/handellm/webrtc-extensions/pull/62.html" title="Last updated on Jan 14, 2021, 3:44 PM UTC (15cbb68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/62/d4a00f1...handellm:15cbb68.html" title="Last updated on Jan 14, 2021, 3:44 PM UTC (15cbb68)">Diff</a>