### PR TITLE
Add a CSP check to RTCPeerConnection.constructor().

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,8 @@
     <p>
       The {{RTCPeerConnection}}
       interface is defined in [[WEBRTC]]. This document extends that interface
-      by adding an additional static method.
+      by adding an additional static method, and adding a Content-Security-Policy
+      check to the constructor.
     </p>
     <pre class="idl">partial interface RTCPeerConnection {
   static sequence&lt;RTCIceServer&gt; getDefaultIceServers();
@@ -138,6 +139,13 @@
           </div>
         </dd>
       </dl>
+    </section>
+    <section>
+      <h2>Modifications to existing procedures</h2>
+
+      <p>In the <a data-cite="WEBRTC#dom-peerconnection">Constructor</a> algorithm,
+      add a step right before step 2 saying "Run [[WEBAPPSEC-CSP#should-block-rtc-connection]]
+      on the current global object. Throw a {{NotAllowedError}} if it returns `Blocked`."</p>
     </section>
   </section>
   <section id="rtcrtptransceiver-interface">


### PR DESCRIPTION
Corresponding change to CSP spec:

https://github.com/w3c/webappsec-csp/pull/457

I'm like 90% sure I've botched the formatting here in one way or another; I still haven't totally gotten my head around how links are generated in these docs, and it seems like there's a bit of inconsistency in how docs are build from spec to spec... so let me know if something's broken...

I'm also a little fuzzy on how the CSP doc should refer to this; right now it links to the constructor section in WebRTC 1.0, but of course this step isn't there, so maybe it should link to the extensions instead?

cc: @annevk, @jan-ivar 