### PR TITLE
Fixing the spec on RTCRtpEncodingParameters.adaptivePtime.

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,15 +546,12 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         frames, and MAY change this at any time. Valid values are multiples
         of 10ms. If the <code>maxptime</code> attribute (defined in
         [[RFC4566]] Section 6) is specified, that maximum applies.
-        <a href="https://w3c.github.io/webrtc-pc/#dfn-read-only-parameter">Read-only parameter.</a></p>
+        If the value is false, the user agent MUST use a fixed frame length.
         <p class="note">Using a longer frame length reduces the
         bandwidth consumption due to overhead, but does so at the cost
         of increased latency. Changing the frame length dynamically allows the
         user agent to adapt its bandwidth allocation strategy based on the
         current network conditions.</p>
-        <p>If <code>adaptivePtime</code> is set to <code>true</code>,
-        <code>ptime</code> MUST NOT be set; otherwise,
-        <code>InvalidModificationError</code> MUST be thrown.</p>
       </dd>
       <dt><dfn data-idl><code>maxFramerate</code></dfn> of type <span class=
       "idlMemberType">double</span></dt>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/minyuel/webrtc-extensions/pull/83.html" title="Last updated on Jun 17, 2021, 7:44 PM UTC (70d9921)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/83/af3b5b1...minyuel:70d9921.html" title="Last updated on Jun 17, 2021, 7:44 PM UTC (70d9921)">Diff</a>