### PR TITLE
Addressing issues with RTCRtpEncodingParameters.adaptivePtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,20 +463,18 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       <dt><dfn data-idl>adaptivePtime</dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.</dt>
       <dd>
         <p>Indicates whether this encoding MAY dynamically change
-        the frame length. If the value is <code>true</code>,
-        the user agent MAY use any valid frame length for any of its
-        frames, and MAY change this at any time. Valid values are multiples
-        of 10ms. If the <code>maxptime</code> attribute (defined in
-        [[RFC4566]] Section 6) is specified, that maximum applies.
-        <a data-cite="WEBRTC#dfn-read-only-parameter">Read-only parameter.</a></p>
+        the frame length. If the value is <code>true</code>, the
+        user agent MAY use any valid frame length for any of its
+        frames, and MAY change this at any time. Valid values are
+        multiples of 10ms. If the <code>maxptime</code> attribute
+        (defined in [[RFC4566]] Section 6) is specified, that maximum
+        applies. If the value is <code>false</code>, the user agent
+        MUST use a fixed frame length.</p>
         <p class="note">Using a longer frame length reduces the
         bandwidth consumption due to overhead, but does so at the cost
         of increased latency. Changing the frame length dynamically allows the
         user agent to adapt its bandwidth allocation strategy based on the
         current network conditions.</p>
-        <p>If {{adaptivePtime}} is set to <code>true</code>,
-        <code>ptime</code> MUST NOT be set; otherwise,
-        {{InvalidModificationError}} MUST be [=exception/throw|thrown=].</p>
       </dd>
       <dt><dfn data-idl>maxFramerate</dfn> of type <span class=
       "idlMemberType">double</span></dt>

--- a/index.html
+++ b/index.html
@@ -472,9 +472,9 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         MUST use a fixed frame length.</p>
         <p class="note">Using a longer frame length reduces the
         bandwidth consumption due to overhead, but does so at the cost
-        of increased latency. Changing the frame length dynamically allows the
-        user agent to adapt its bandwidth allocation strategy based on the
-        current network conditions.</p>
+        of increased latency. Changing the frame length dynamically
+        allows the user agent to adapt its bandwidth allocation strategy
+        based on the current network conditions.</p>
         <p>If {{adaptivePtime}} is set to <code>true</code>,
         <code>ptime</code> MUST NOT be set; otherwise,
         {{InvalidModificationError}} MUST be [=exception/throw|thrown=].</p>

--- a/index.html
+++ b/index.html
@@ -475,6 +475,9 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         of increased latency. Changing the frame length dynamically allows the
         user agent to adapt its bandwidth allocation strategy based on the
         current network conditions.</p>
+        <p>If {{adaptivePtime}} is set to <code>true</code>, {{ptime}}
+        MUST NOT be set; otherwise, {{InvalidModificationError}} MUST be
+        [=exception/throw|thrown=].</p>
       </dd>
       <dt><dfn data-idl>maxFramerate</dfn> of type <span class=
       "idlMemberType">double</span></dt>

--- a/index.html
+++ b/index.html
@@ -476,7 +476,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         user agent to adapt its bandwidth allocation strategy based on the
         current network conditions.</p>
         <p>If {{adaptivePtime}} is set to <code>true</code>,
-        {{ptime}} MUST NOT be set; otherwise,
+        <code>ptime</code> MUST NOT be set; otherwise,
         {{InvalidModificationError}} MUST be [=exception/throw|thrown=].</p>
       </dd>
       <dt><dfn data-idl>maxFramerate</dfn> of type <span class=

--- a/index.html
+++ b/index.html
@@ -475,9 +475,6 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         of increased latency. Changing the frame length dynamically
         allows the user agent to adapt its bandwidth allocation strategy
         based on the current network conditions.</p>
-        <p>If {{adaptivePtime}} is set to <code>true</code>,
-        <code>ptime</code> MUST NOT be set; otherwise,
-        {{InvalidModificationError}} MUST be [=exception/throw|thrown=].</p>
       </dd>
       <dt><dfn data-idl>maxFramerate</dfn> of type <span class=
       "idlMemberType">double</span></dt>

--- a/index.html
+++ b/index.html
@@ -475,9 +475,9 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         of increased latency. Changing the frame length dynamically allows the
         user agent to adapt its bandwidth allocation strategy based on the
         current network conditions.</p>
-        <p>If {{adaptivePtime}} is set to <code>true</code>, {{ptime}}
-        MUST NOT be set; otherwise, {{InvalidModificationError}} MUST be
-        [=exception/throw|thrown=].</p>
+        <p>If {{adaptivePtime}} is set to <code>true</code>,
+        {{ptime}} MUST NOT be set; otherwise,
+        {{InvalidModificationError}} MUST be [=exception/throw|thrown=].</p>
       </dd>
       <dt><dfn data-idl>maxFramerate</dfn> of type <span class=
       "idlMemberType">double</span></dt>

--- a/index.html
+++ b/index.html
@@ -450,9 +450,9 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       RTCRtpEncodingParameters extensions
     </h3>
     <p>
-      The {{RTCRtpEncodingParameters}}
-      dictionary is defined in [[WEBRTC]]. This document extends that dictionary
-      by adding an additional boolean flag.
+      The {{RTCRtpEncodingParameters}} dictionary is defined in
+      [[WEBRTC]]. This document extends that dictionary with
+      additional members.
     </p>
     <pre class="idl">partial dictionary RTCRtpEncodingParameters {
       boolean adaptivePtime = false;


### PR DESCRIPTION
Related to Issue https://github.com/w3c/webrtc-extensions/issues/74

Rebase of https://github.com/w3c/webrtc-extensions/pull/83


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/89.html" title="Last updated on Nov 18, 2021, 3:50 PM UTC (c9e46ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/89/33329ae...c9e46ab.html" title="Last updated on Nov 18, 2021, 3:50 PM UTC (c9e46ab)">Diff</a>