### PR TITLE
maxFramerate now implemented

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,10 +493,6 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         rate to zero thus has the effect of freezing the video on the next
         frame. Upon setting with {{RTCRtpSender/setParameters()}}, if the value is
         less than 0.0, [=reject=] with a {{RangeError}}.</p>
-        <div class="issue atrisk">
-          <p>{{maxFramerate}} was moved from [[WEBRTC]] to this
-          extension spec due to lack of support from implementers.</p>
-        </div>
       </dd>
     </dl>
   </section>


### PR DESCRIPTION
Revision to implementation text to reflect that `maxFramerate` is now supported in Chromium. 

Related to Issue https://github.com/w3c/webrtc-extensions/issues/80


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/91.html" title="Last updated on Nov 14, 2021, 7:58 PM UTC (dd3bfba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/91/33329ae...dd3bfba.html" title="Last updated on Nov 14, 2021, 7:58 PM UTC (dd3bfba)">Diff</a>