### PR TITLE
maxFramerate now implemented

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,10 +494,6 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         rate to zero thus has the effect of freezing the video on the next
         frame. Upon setting with {{RTCRtpSender/setParameters()}}, if the value is
         less than 0.0, [=reject=] with a {{RangeError}}.</p>
-        <div class="issue atrisk">
-          <p>{{maxFramerate}} was moved from [[WEBRTC]] to this
-          extension spec due to lack of support from implementers.</p>
-        </div>
       </dd>
     </dl>
   </section>


### PR DESCRIPTION
Revision to implementation text to reflect that `maxFramerate` is now supported in Chromium. 

Related to Issue https://github.com/w3c/webrtc-extensions/issues/80


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/92.html" title="Last updated on Nov 15, 2021, 1:25 PM UTC (42322f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/92/f0b6403...42322f1.html" title="Last updated on Nov 15, 2021, 1:25 PM UTC (42322f1)">Diff</a>