### PR TITLE
RTP Header Extensions Encryption (cryptex)

### DIFF
--- a/index.html
+++ b/index.html
@@ -747,8 +747,8 @@ partial interface RTCRtpTransceiver {
         </dt>
         <dd>
          <p>
-             The {{rtpHeaderEncryptionNegotiated}} attribute is indicates whether
-             RTP header extension encryption has been negotiated.  On getting, the attribute MUST
+             The {{rtpHeaderEncryptionNegotiated}} attribute indicates whether [[CRYPTEX]] has been
+             negotiated.  On getting, the attribute MUST
              return the value of the {{RTCRtpTransceiver/[[RtpHeaderEncryptionNegotiated]]}} slot.
              In [[WEBRTC]] Section 5.4, add the following step to "create an {{RTCRtpTransceiver}}":
              Let <var>transceiver</var> have a <dfn data-dfn-for="RTCRtpTransceiver">[[\RtpHeaderEncryptionNegotiated]]</dfn>

--- a/index.html
+++ b/index.html
@@ -678,10 +678,10 @@ partial interface RTCDataChannel {
         <dfn>RTCRtpHeaderEncryptionPolicy</dfn> Enum
      </h3>
      <p>
-       RTP header encryption policy affects whether RTP header encryption is
-       negotiated if the remote endpoint is not cryptex-aware. If the remote
-       endpoint is cryptex-aware, all media streams are sent utilizing RTP
-       header encryption.
+       RTP header extension encryption policy affects whether RTP header extension
+       encryption is negotiated if the remote endpoint does not support [[CRYPTEX]].
+       If the remote endpoint supports [[CRYPTEX]], all media streams are sent
+       utilizing [[CRYPTEX]]. 
      </p>
      <div>
          <pre id="target-rtp-header-encryption-policy" class="idl">enum RTCRtpHeaderEncryptionPolicy {
@@ -696,15 +696,67 @@ partial interface RTCDataChannel {
           </tr>
           <tr>
             <td><dfn data-idl>negotiate</dfn></td>
-            <td>Negotiate RTP header encryption.</td>
+            <td>
+              <p>
+                Negotiate RTP header extension encryption as defined in [[CRYPTEX]].
+                If encryption cannot be negotiated, RTP header extensions are sent in
+                the clear.
+              <p>
+            </td>
           </tr>
           <tr>
             <td><dfn data-idl>require</dfn></td>
-            <td>Require RTP header encryption.</td>
+            <td>
+              <p>
+                Require RTP header extension encryption. In [[WEBRTC]] Section 4.4.1.5, add the
+                following check after Step 4.4.4:
+                If <var>remote</var> is <code>true</code>, the <var>connection</var>'s
+                {{RTCRtpHeaderEncryptionPolicy}} is {{RTCRtpHeaderEncryptionPolicy/require}}
+                and the description does not support [[CRYPTEX]], then [= reject =] <var>p</var>
+                with a newly [= exception/created =] {{InvalidAccessError}} and abort these steps.
+              </p>
+            </td>
           </tr>
         </tbody>
       </table>
     </div>
+  </section>
+  <section id="transceiver">
+    <h3>
+      {{RTCRtpTransceiver}} extensions
+    </h3>
+      <p>
+         {{RTCRtpTransceiver/rtpHeaderEncryptionNegotiated}} defines whether
+         the transceiver is sending enrypted RTP header extensions as defined in
+         [[CRYPTEX]].
+      </p>
+      <div>
+ <pre class="idl">
+partial interface RTCRtpTransceiver {
+  readonly attribute boolean rtpHeaderEncryptionNegotiated;
+};</pre>
+    <section>
+       <h2>
+         Attributes
+       </h2>
+       <dl data-link-for="RTCRtpTransceiver" data-dfn-for=
+       "RTCRtpTransceiver" class="attributes">
+       <dt>
+         <dfn id="dom-rtptransceiver-rtpHeaderEncryptionNegotiated">rtpHeaderEncryptionNegotiated</dfn> of type <span class=
+                "idlAttrType">Boolean</span>, readonly, nullable
+        </dt>
+        <dd>
+         <p>
+             The {{rtpHeaderEncryptionNegotiated}} attribute is indicates whether
+             RTP header extension encryption has been negotiated.  On getting, the attribute MUST
+             return the value of the {{RTCRtpTransceiver/[[RtpHeaderEncryptionNegotiated]]}} slot.
+             In [[WEBRTC]] Section 5.4, add the following step to "create an {{RTCRtpTransceiver}}":
+             Let <var>transceiver</var> have a <dfn data-dfn-for="RTCRtpTransceiver">[[\RtpHeaderEncryptionNegotiated]]</dfn>
+             internal slot, initialized to <code>false</code>.
+          </p>
+        </dd>
+       </dl>    
+     </section>
   </section>
   <section id="configuration">
     <h3>

--- a/index.html
+++ b/index.html
@@ -671,6 +671,79 @@ partial interface RTCDataChannel {
       the {{RTCDataChannel}} object will be closed by running the <a href="WEBRTC#announcing-a-data-channel-as-closed">announcing a data channel as closed</a> algorithm immediately after the <a data-cite="!HTML/#transfer-receiving-steps">transfer-receiving steps</a>.</p>
     </div>
 </section>
+<section id="rtpHeaderEncryption">
+     <h3>RTP Header Extension Encryption</h3>
+<section id="rtpHeaderEncryptionPolicy">
+     <h3>
+        <dfn>RTCRtpHeaderEncryptionPolicy</dfn> Enum
+     </h3>
+     <p>
+       RTP header encryption policy affects whether RTP header encryption is
+       negotiated if the remote endpoint is not cryptex-aware. If the remote
+       endpoint is cryptex-aware, all media streams are sent utilizing RTP
+       header encryption.
+     </p>
+     <div>
+         <pre id="target-rtp-header-encryption-policy" class="idl">enum RTCRtpHeaderEncryptionPolicy {
+"negotiate",
+"require"
+};</pre>
+      <table data-link-for="RTCRtpHeaderEncryptionPolicy" data-dfn-for=
+      "RTCRtpHeaderEncryptionPolicy" class="simple">
+        <tbody>
+          <tr>
+            <th colspan="2">Enumeration description (non-normative)</th>
+          </tr>
+          <tr>
+            <td><dfn data-idl>negotiate</dfn></td>
+            <td>Negotiate RTP header encryption.</td>
+          </tr>
+          <tr>
+            <td><dfn data-idl>require</dfn></td>
+            <td>Require RTP header encryption.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+  <section id="configuration">
+    <h3>
+      {{RTCConfiguration}} extensions
+    </h3>
+          <p>
+            {{RTCConfiguration/rtpHeaderEncryptionPolicy}} defines the
+            policy for negotiation of RTP header encryption using
+            [[CRYPTEX]].
+          </p>
+          <div>
+            <pre class="idl">partial dictionary RTCConfiguration {
+  RTCRtpHeaderEncryptionPolicy rtpHeaderEncryptionPolicy = "negotiate";
+};</pre>
+      <section>
+              <h2>
+                Dictionary {{RTCConfiguration}} Members
+              </h2>
+              <dl data-link-for="RTCConfiguration" data-dfn-for=
+              "RTCConfiguration" class="dictionary-members">
+              <dt>
+                <dfn data-idl="">rtpHeaderEncryptionPolicy</dfn> of type <span class=
+                "idlMemberType">RTCRtpHeaderEncryptionPolicy</span>
+              </dt>
+              <dd>
+                <p class="needs-test">
+                </p>
+                <div class="issue atrisk">
+                  <p>
+                    {{RTCConfiguration/rtpHeaderEncryptionPolicy}} is marked
+                    as a feature at risk, since there is no clear commitment
+                    from implementers.
+                  </p>
+                </div>
+              </dd>
+            </dl>
+       </section>
+  </section>
+</section>
 <section id="removed-features">
     <h3>Removed features</h3>
     <p>


### PR DESCRIPTION
Fixes Issue https://github.com/w3c/webrtc-extensions/issues/47


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 28, 2022, 7:26 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebrtc-extensions%2F3f205451355a6d81a11172b55bd95c0ad1673074%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/aMO1i8
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-extensions%23106.)._
</details>
