### PR TITLE
add sender/receiver extensions to disable hardware encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,10 +783,10 @@ partial interface RTCRtpTransceiver {
     <dfn data-dfn-for=RTCRtpReceiver>{{RTCRtpReceiver/[[HardwareDisabled]]}}</dfn> initialized to <code>false</code>.
   </p>
   <pre class="idl">partial interface RTCRtpReceiver {
-    static undefined disableHardwareEncoding();
+    static undefined disableHardwareDecoding();
 };
 </pre>
-  <p>When the {{RTCRtpReceiver}}'s disableHardwareEncoding method is called, the user agent MUST run the following steps:</p>
+  <p>When the {{RTCRtpReceiver}}'s disableHardwareDecoding method is called, the user agent MUST run the following steps:</p>
   <ol>
     <li>
       <p>When the <code>RTCPeerConnection.constructor()</code> has been invoked abort these steps.</p>

--- a/index.html
+++ b/index.html
@@ -820,12 +820,16 @@ partial interface RTCRtpTransceiver {
   <p>
     In the <a data-cite="WEBRTC#set-description">set a session description</a> algorithm, add a step
     right after the step that sets transceiver.[[\Receiver]].[[\ReceiveCodecs]],
-    saying "If the RTCRtpReceiver's {{RTCRtpReceiver/[[HardwareDisabled]]}} slot is <code>true</code>, remove any codec from transceiver.[[\Receiver]].[[\ReceiveCodecs]] for which the underlying encoder is hardware-accelerated.
+    saying "If the RTCRtpReceiver's {{RTCRtpReceiver/[[HardwareDisabled]]}} slot is <code>true</code>,
+    remove any codec from transceiver.[[\Receiver]].[[\ReceiveCodecs]] for which the underlying decoder
+    is hardware-accelerated.
   </p>
   <p>
     In the <a data-cite="WEBRTC#set-description">set a session description</a> algorithm, add a step
     right after the step that sets transceiver.[[\Sender]].[[\SendCodecs]],
-    saying "If the RTCRtpSender's {{RTCRtpSender/[[HardwareDisabled]]}} slot is <code>true</code>, remove any codec from transceiver.[[\Sender]].[[\SendCodecs]] for which the underlying encoder is hardware-accelerated.
+    saying "If the RTCRtpSender's {{RTCRtpSender/[[HardwareDisabled]]}} slot is <code>true</code>,
+    remove any codec from transceiver.[[\Sender]].[[\SendCodecs]] for which the underlying encoder
+    is hardware-accelerated.
   </p>
 </section>
 <section id="removed-features">

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
       <p>
         In the <a data-cite="WEBRTC#set-description">set a session description</a> algorithm, add a step
         right after the step that sets transceiver.[[\Sender]].[[\SendCodecs]],
-        saying "For each transciever, set {{RTCRtpTransceiver/[[HeaderExtensionsNegotiated]]}} to
+        saying "For each transceiver, set {{RTCRtpTransceiver/[[HeaderExtensionsNegotiated]]}} to
         an empty list, and then
         for each <code>"a=hdrext"</code> line, add an appropriate
         {{RTCRtpHeaderExtensionCapability}} to the list.
@@ -759,6 +759,74 @@ partial interface RTCRtpTransceiver {
             </dl>
        </section>
   </section>
+</section>
+<section id="disable-hardware">
+  <h2>Disabling hardware acceleration</h2>
+  <p>
+    While hardware acceleration of video encoding and decoding is generally desirable, it has proven to be
+    operationally challenging to achieve in the environment of a browser with no detailed information about
+    the underlying hardware. In some cases, falling back to software encoding yields better results.
+  <p>
+  <p class="note">
+    The methods specified in this section should be used sparingly and not for extended amounts of time.
+   </p>
+  <p class="note">
+    In privacy-sensitive contexts, browsers may disable hardware acceleration by default to
+    reduce the fingerprinting surface.
+  </p>
+  <h3>
+    {{RTCRtpReceiver}} extensions
+  </h3>
+  <p>
+    The {{RTCRtpReceiver}} interface is defined in [[WEBRTC]]. This document extends this interface
+    by adding a static method and internal slot
+    <dfn data-dfn-for=RTCRtpReceiver>{{RTCRtpReceiver/[[HardwareDisabled]]}}</dfn> initialized to <code>false</code>.
+  </p>
+  <pre class="idl">partial interface RTCRtpReceiver {
+    static undefined disableHardwareEncoding();
+};
+</pre>
+  <p>When the {{RTCRtpReceiver}}'s disableHardwareEncoding method is called, the user agent MUST run the following steps:</p>
+  <ol>
+    <li>
+      <p>When the <code>RTCPeerConnection.constructor()</code> has been invoked abort these steps.</p>
+    </li>
+    <li>
+      <p>Set the RTCRtpReceiver's {{RTCRtpReceiver/[[HardwareDisabled]]}} slot to <code>true</code>.</p>
+    </li>
+  </ol>
+  <h3>
+    {{RTCRtpSender}} extensions
+  </h3>
+  <p>
+    The {{RTCRtpSender}} interface is defined in [[WEBRTC]]. This document extends this interface
+    by adding a static method and internal slot
+    <dfn data-dfn-for=RTCRtpSender>{{RTCRtpSender/[[HardwareDisabled]]}}</dfn> initialized to <code>false</code>.
+  </p>
+  <pre class="idl">partial interface RTCRtpSender {
+    static undefined disableHardwareEncoding();
+};
+</pre>
+  <p>When the {{RTCRtpSender}}'s disableHardwareEncoding method is called, the user agent MUST run the following steps:</p>
+  <ol>
+    <li>
+      <p>When the <code>RTCPeerConnection.constructor()</code> has been invoked abort these steps.</p>
+    </li>
+    <li>
+      <p>Set the RTCRtpSender's {{RTCRtpSender/[[HardwareDisabled]]}} slot to <code>true</code>.</p>
+    </li>
+  </ol>
+  <h3>Modifications to existing procedures</h3>
+  <p>
+    In the <a data-cite="WEBRTC#set-description">set a session description</a> algorithm, add a step
+    right after the step that sets transceiver.[[\Receiver]].[[\ReceiveCodecs]],
+    saying "If the RTCRtpReceiver's {{RTCRtpReceiver/[[HardwareDisabled]]}} slot is <code>true</code>, remove any codec from transceiver.[[\Receiver]].[[\ReceiveCodecs]] for which the underlying encoder is hardware-accelerated.
+  </p>
+  <p>
+    In the <a data-cite="WEBRTC#set-description">set a session description</a> algorithm, add a step
+    right after the step that sets transceiver.[[\Sender]].[[\SendCodecs]],
+    saying "If the RTCRtpSender's {{RTCRtpSender/[[HardwareDisabled]]}} slot is <code>true</code>, remove any codec from transceiver.[[\Sender]].[[\SendCodecs]] for which the underlying encoder is hardware-accelerated.
+  </p>
 </section>
 <section id="removed-features">
     <h3>Removed features</h3>

--- a/index.html
+++ b/index.html
@@ -822,14 +822,14 @@ partial interface RTCRtpTransceiver {
     right after the step that sets transceiver.[[\Receiver]].[[\ReceiveCodecs]],
     saying "If the RTCRtpReceiver's {{RTCRtpReceiver/[[HardwareDisabled]]}} slot is <code>true</code>,
     remove any codec from transceiver.[[\Receiver]].[[\ReceiveCodecs]] for which the underlying decoder
-    is hardware-accelerated.
+    is hardware-accelerated".
   </p>
   <p>
     In the <a data-cite="WEBRTC#set-description">set a session description</a> algorithm, add a step
     right after the step that sets transceiver.[[\Sender]].[[\SendCodecs]],
     saying "If the RTCRtpSender's {{RTCRtpSender/[[HardwareDisabled]]}} slot is <code>true</code>,
     remove any codec from transceiver.[[\Sender]].[[\SendCodecs]] for which the underlying encoder
-    is hardware-accelerated.
+    is hardware-accelerated".
   </p>
 </section>
 <section id="removed-features">


### PR DESCRIPTION
fix for #98

See https://www.w3.org/2022/09/12-webrtc-minutes.html#t18 for TPAC discussion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-extensions/pull/128.html" title="Last updated on Dec 1, 2022, 4:05 PM UTC (5b99b64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/128/648734d...fippo:5b99b64.html" title="Last updated on Dec 1, 2022, 4:05 PM UTC (5b99b64)">Diff</a>