### PR TITLE
Replace "a=hdrext" with "a=extmap"

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@ sequence&lt;RTCRtpHeaderExtensionCapability&gt; headerExtensionsToOffer);
         right after the step that sets transceiver.[[\Sender]].[[\SendCodecs]],
         saying "For each transciever, set {{RTCRtpTransceiver/[[HeaderExtensionsNegotiated]]}} to
         an empty list, and then
-        for each <code>"a=hdrext"</code> line, add an appropriate
+        for each <code>"a=extmap"</code> line, add an appropriate
         {{RTCRtpHeaderExtensionCapability}} to the list.
       </p>
       <p>


### PR DESCRIPTION
Fixes #131


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/133.html" title="Last updated on Dec 4, 2022, 1:17 PM UTC (cd01f9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/133/648734d...cd01f9a.html" title="Last updated on Dec 4, 2022, 1:17 PM UTC (cd01f9a)">Diff</a>