### PR TITLE
Make RTCRtpHeaderExtensionCapability attributes required

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,9 +122,7 @@
       RTP header extensions.
     </p>
     <pre class="idl">
-// This definition replaces that of webrtc-pc, making `uri` required.
-dictionary RTCRtpHeaderExtensionCapability {
-  required DOMString uri;
+partial dictionary RTCRtpHeaderExtensionCapability {
   required RTCRtpTransceiverDirection direction;
 };
 

--- a/index.html
+++ b/index.html
@@ -122,8 +122,10 @@
       RTP header extensions.
     </p>
     <pre class="idl">
-partial dictionary RTCRtpHeaderExtensionCapability {
-  RTCRtpTransceiverDirection direction = "sendrecv";
+// This definition replaces that of webrtc-pc, making `uri` required.
+dictionary RTCRtpHeaderExtensionCapability {
+  required DOMString uri;
+  required RTCRtpTransceiverDirection direction;
 };
 
 partial interface RTCRtpTransceiver {
@@ -322,13 +324,6 @@ partial interface RTCRtpTransceiver {
                 <li>
                   <p>Let <var>extension</var> be the <var>i</var>-th element of
                   <var>extensions</var>.</p>
-                </li>
-                <li>
-                  <p>If
-                  <var>extension</var>.{{RTCRtpHeaderExtensionCapability/uri}}
-                  or
-                  <var>extension</var>.{{RTCRtpHeaderExtensionCapability/direction}}
-                  is missing, [=exception/throw=] a {{TypeError}}.</p>
                 </li>
                 <li>
                   <p>If


### PR DESCRIPTION
Fixes #144.
- The manual "is missing" checks are no longer needed because WebIDL ensures required for us.
- The default value "sendrecv" is not needed, removed because required attributes may not have defaults.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-extensions/pull/145.html" title="Last updated on Mar 16, 2023, 2:42 PM UTC (e3f92be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/145/47c4630...henbos:e3f92be.html" title="Last updated on Mar 16, 2023, 2:42 PM UTC (e3f92be)">Diff</a>