### PR TITLE
Add RTCRtpEncodingParameters.codec to change the active codec

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@ partial interface RTCRtpTransceiver {
         <dd>
           <p>Optional value selecting which codec is used for this encoding's
             RTP stream. The {{RTCRtpCodec}} dictionary is defined in [[WEBRTC]].
-            If absent, the user agent can chose to use any negotiated codec.</p>
+            If [=map/exists|absent=], the user agent can chose to use any negotiated codec.</p>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -523,6 +523,7 @@ partial interface RTCRtpTransceiver {
     <pre class="idl">partial dictionary RTCRtpEncodingParameters {
   unsigned long ptime;
   boolean adaptivePtime = false;
+  RTCRtpCodec codec;
 };</pre>
     <section id="rtcrtpencodingparameters-attributes">
       <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
@@ -562,7 +563,79 @@ partial interface RTCRtpTransceiver {
           allows the <a>user agent</a> to adapt its bandwidth allocation strategy
           based on the current network conditions.</p>
         </dd>
+        <dt>
+          <dfn data-idl>codec</dfn> of type <span class="idlMemberType">RTCRtpCodec</span>
+        </dt>
+        <dd>
+          <p>Optional value selecting which codec is used for this encoding's
+            RTP stream. The {{RTCRtpCodec}} dictionary is defined in [[WEBRTC]].
+            If absent, the user agent can chose to use any negotiated codec.</p>
+        </dd>
       </dl>
+    </section>
+    <section id="rtcrtpencodingparameters-modifications">
+      <h2>Modifications to existing procedures</h2>
+      <h3>setParameters()</h3>
+      <p>Add the following steps to the [=RTCRtpSender/setParameters validation steps=]:</p>
+      <ol>
+        <li>
+          <p>Let <var>choosableCodecs</var> be parameters.{{RTCRtpParameters/codecs}}.</p>
+        </li>
+        <li>
+          <p>If <var>choosableCodecs</var> is an empty list, set <var>choosableCodecs</var>
+            to transceiver.{{RTCRtpTransceiver/[[PreferredCodecs]]}}.</p>
+        </li>
+        <li>
+            <p>If <var>choosableCodecs</var> is still an empty list, set <var>choosableCodecs</var>
+              to the [=RTCRtpSender/list of implemented send codecs=] for transceiver's kind.</p>
+        </li>
+        <li>
+          <p>If any <var>encoding</var> in encodings [=map/exists|contains=] a codec
+            [= codec match | not found =] in <var>choosableCodecs</var>, return a promise
+            [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</p>
+        </li>
+        <li>
+          <p>If the user agent does not support setting the codec for any encoding or mixing
+            different codec values on the different encodings, return a promise [= rejected =]
+            with a newly [= exception/created =] {{OperationError}}.
+          </p>
+        </li>
+      </ol>
+      <h3>addTransceiver()</h3>
+      <p>Add the following steps to the [=RTCPeerConnection/addTransceiver sendEncodings validation steps=]:</p>
+      <ol>
+        <li>
+          <p>If any <var>codec</var> parameter in <var>sendEncodings</var> does [= codec match | not match =] any codec in
+          {{RTCRtpSender.getCapabilities(kind)}}.<code>codecs</code>,
+          [= exception/throw =] an {{OperationError}}.</p>
+        </li>
+        <li>
+          <p>If the user agent does not support changing codecs without negotiation or
+            does not support setting codecs for individual encodings, return a promise
+            [= rejected =] with a newly [= exception/created =] {{OperationError}}.</p>
+        </li>
+      </ol>
+      <h3>Set the session description</h3>
+      <p>Append the following steps to the <a data-cite="WEBRTC#set-description">set the session description</a> algorithm:</p>
+      <ol>
+        <li>
+          <p>For each <var>transceiver</var> in <var>connection</var>'s [= set of transceivers =]:</p>
+          <ol>
+            <li>
+              <p>Let <var>codecs</var> be <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendCodecs]]}}.</p>
+            </li>
+            <li>
+              <p>If <var>codecs</var> is not an empty list:</p>
+              <ol>
+                <li>
+                  <p>Remove any <var>codec</var> value in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
+                    that does not [= codec match | match =] any entry in <var>codecs</var>.</p>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+      </ol>
     </section>
   </section>
   <section id="rtcrtpcontributingsource-extensions">

--- a/webrtc-extensions.js
+++ b/webrtc-extensions.js
@@ -5,7 +5,7 @@ var respecConfig = {
       repoURL: "https://github.com/w3c/webrtc-extensions/",
       branch: "main"
     },
-    "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats"],
+    "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "infra"],
     "shortName": "webrtc-extensions",
     "specStatus": "ED",
     "subjectPrefix": "[webrtc-extensions]",


### PR DESCRIPTION
This new encoding parameter allows changing the active codec on any simulcast layer as long as it is supported or negotiated.

It allows user agent that don't support the feature partially or fully to reject the configuration change.

Fixes #43 , #126


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Orphis/webrtc-extensions/pull/147.html" title="Last updated on Apr 20, 2023, 2:29 PM UTC (a088a4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/147/7f7b5f9...Orphis:a088a4f.html" title="Last updated on Apr 20, 2023, 2:29 PM UTC (a088a4f)">Diff</a>