### PR TITLE
clean up audio rtp parameters extensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -511,23 +511,25 @@ partial interface RTCRtpTransceiver {
       </dl>
     </section>
   </section>
-  <section id="rtcrtpencodingparameters-extension">
+  <section id="rtcrtpencodingparameters-audio-packetization">
     <h3>
-      RTCRtpEncodingParameters extensions
+      RTCRtpEncodingParameters extensions for audio packetization
     </h3>
     <p>
       The {{RTCRtpEncodingParameters}} dictionary is defined in
       [[WEBRTC]]. This document extends that dictionary with
-      additional members.
+      additional members to control audio packetization.
     </p>
     <pre class="idl">partial dictionary RTCRtpEncodingParameters {
   unsigned long ptime;
   boolean adaptivePtime = false;
 };</pre>
-    <section id="rtcrtpencodingparameters-attributes">
+    <section id="rtcrtpencodingparameters-audio-packetization-attributes">
       <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
       <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for="RTCRtpEncodingParameters" class="dictionary-members">
-        <dt><dfn data-idl>ptime</dfn> of type <span class="idlMemberType">unsigned long</span></dt>
+        <dt>
+          <dfn data-idl>ptime</dfn> of type <span class="idlMemberType">unsigned long</span>
+        </dt>
         <dd>
           <p>The preferred duration of media represented by a packet in milliseconds.</p>
             <div class="issue atrisk">
@@ -538,7 +540,10 @@ partial interface RTCRtpTransceiver {
               </p>
             </div>
         </dd>
-        <dt><dfn data-idl>adaptivePtime</dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.</dt>
+        <dt>
+          <dfn data-idl>adaptivePtime</dfn> of type <span class="idlMemberType">boolean</span>,
+          defaulting to <code>false</code>.
+        </dt>
         <dd>
           <p>Indicates whether this encoding MAY dynamically change
           the frame length. If the value is <code>true</code>, the


### PR DESCRIPTION
editorial so far. I wonder if we should have text along these lines (not sure where I borrowed from):
```
In the steps to call the {{setParameters}} method modify the step to validate parameters and
remove {{ptime}} if [= transceiver kind =] is `"video"`.
```
(same for adaptivePtime)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-extensions/pull/154.html" title="Last updated on Mar 29, 2023, 7:56 AM UTC (25edb8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/154/5cf8803...fippo:25edb8e.html" title="Last updated on Mar 29, 2023, 7:56 AM UTC (25edb8e)">Diff</a>