### PR TITLE
Remove superfluous closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
       This document defines a set of ECMAScript APIs in WebIDL to extend the WebRTC 1.0 API.
     </p>
   </section>
-  </section>
   <section id="sotd">
     <p>The API is based on preliminary work done in the W3C WEBRTC Working Group.</p>
   </section>


### PR DESCRIPTION
I've noticed that the last PR introduced an extra `</section>`. This PR just removes it again.

https://github.com/w3c/webrtc-extensions/blob/c1c6b0fdd0ea3fb51f801846e702b179d3960827/index.html#L15-L16


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisguttandin/webrtc-extensions/pull/161.html" title="Last updated on Apr 20, 2023, 9:22 PM UTC (3f2c493)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/161/c1c6b0f...chrisguttandin:3f2c493.html" title="Last updated on Apr 20, 2023, 9:22 PM UTC (3f2c493)">Diff</a>