### PR TITLE
Remove JSEP Modifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,9 +207,9 @@ partial interface RTCRtpTransceiver {
         </li>
       </ul>
     <p>
-      In [[JSEPbis]] Sections 5.2.1 and 5.2.2 an RTP header extension "e" is considered "enabled" if it is
-      listed in {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} where {{RTCRtpHeaderExtensionCapability/direction}} is not 
-      {{RTCRtpTransceiverDirection/"stopped"}}.
+      In [[JSEPbis]] Section 5.2.1 (Initial Offers) and 5.2.2 (Subsequent Answers) an RTP header extension "e" is
+      considered "enabled" if it is listed in {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} where
+      {{RTCRtpHeaderExtensionCapability/direction}} is not {{RTCRtpTransceiverDirection/"stopped"}}.
     </p>
     </section>
     <section id="rtp-header-extension-control-transceiver-methods">

--- a/index.html
+++ b/index.html
@@ -206,34 +206,6 @@ partial interface RTCRtpTransceiver {
           </ol>
         </li>
       </ul>
-      <p>
-        In the algorithms for generating initial offers in [[RTCWEB-JSEP]] section 5.2.1,
-        replace "for each supported RTP header extension, an "a=extmap" line, as specified in
-        [[RFC5285]], section 5" " with "For each RTP header extension "e"
-        listed in {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} where {{RTCRtpHeaderExtensionCapability/direction}} is not {{RTCRtpTransceiverDirection/"stopped"}}, an "a=extmap"
-        line, as specified in [[RFC5285]], section 5, with direction taken from "e"'s {{RTCRtpHeaderExtensionCapability/direction}}
-        attribute."
-      </p>
-      <p>
-        In the algorithm for generating subsequent offers in [[RTCWEB-JSEP]] section 5.2.2, replace "The
-        RTP header extensions MUST only include those that are present in the most recent answer"
-        with "For each RTP header extension listed in {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}},
-        and where {{RTCRtpHeaderExtensionCapability/direction}} is not {{RTCRtpTransceiverDirection/"stopped"}}, generate
-        an appropriate "a=extmap" line with "direction" set according to the rules of [[RFC5285]]
-        section 6, considering the {{RTCRtpHeaderExtensionCapability/direction}} in {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} to indicate the
-        answerer's desired usage".
-      </p>
-      <p>
-        In the algorithm for generating initial answers in [[RTCWEB-JSEP]] section 5.3.1, replace "For
-        each supported RTP header extension that is present in the offer" with "For each
-        supported RTP header extension that is present in the offer and is also present in
-        {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} with a {{RTCRtpHeaderExtensionCapability/direction}} different from {{RTCRtpTransceiverDirection/"stopped"}},
-        set the appropriate direction based on {{RTCRtpHeaderExtensionCapability/direction}} that does not exceed the direction in the offer".
-      </p>
-      <p class="note">
-        Since JSEP does not know about WebRTC internal slots, merging this change requires
-        more work on a JSEP revision.
-      </p>
     </section>
     <section id="rtp-header-extension-control-transceiver-methods">
       <h3>Methods</h3>

--- a/index.html
+++ b/index.html
@@ -206,6 +206,11 @@ partial interface RTCRtpTransceiver {
           </ol>
         </li>
       </ul>
+    <p>
+      In [[JSEPbis]] Sections 5.2.1 and 5.2.2 an RTP header extension "e" is considered "enabled" if it is
+      listed in {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} where {{RTCRtpHeaderExtensionCapability/direction}} is not 
+      {{RTCRtpTransceiverDirection/"stopped"}}.
+    </p>
     </section>
     <section id="rtp-header-extension-control-transceiver-methods">
       <h3>Methods</h3>

--- a/index.html
+++ b/index.html
@@ -404,7 +404,6 @@ partial interface RTCRtpTransceiver {
                   <p>Update the underlying system about the new <var>target</var>,
                   or that there is no application preference if <var>target</var> is
                   <code>null</code>.</p>
-                </li>
                 <p>
                   If <var>track</var> is synchronized with another
                   {{RTCRtpReceiver}}'s track for
@@ -417,13 +416,14 @@ partial interface RTCRtpTransceiver {
                   continuously make sure that the actual jitter buffer target is clamped
                   within the <a>minimum allowed target</a> and <a>maximum allowed
                   target</a>.
+                </p>
                   <p class="note">
                     If the <a>user agent</a> ends up using a target different from the
                     requested one (e.g. due to network conditions or physical memory
                     constraints), this is not reflected in the
                     {{RTCRtpReceiver/[[JitterBufferTarget]]}} internal slot.
                   </p>
-                </p>
+                </li>
                 <li>
                   <p>Modifying the jitter buffer target of the underlying system SHOULD
                   affect the internal audio or video buffering gradually in order not

--- a/webrtc-extensions.js
+++ b/webrtc-extensions.js
@@ -43,6 +43,11 @@ var respecConfig = {
       },
       "CRYPTEX": {
 	"aliasOf": "RFC9335"
-    }
+      },
+      "JSEPbis": {
+	"title": "JavaScript Session Establishment Protocol (JSEP) - bis",
+	"href": "https://www.ietf.org/archive/id/draft-uberti-rtcweb-rfc8829bis-04.html",
+	"publisher": "IETF"
+      }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-extensions/pull/134

There is an existing process for submitting RFC 8829 errata, as well as for updating RFC 8829bis (now in the RFC Editor queue).  Let's see if we can address these JSEP issues some other way.  Justin Uberti will join us at the May 4 WEBRTC WG Editor's meeting to discuss alternatives.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aboba/webrtc-extensions/pull/164.html" title="Last updated on May 16, 2023, 9:45 AM UTC (d2869bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/164/51024d3...aboba:d2869bd.html" title="Last updated on May 16, 2023, 9:45 AM UTC (d2869bd)">Diff</a>