### PR TITLE
Request keyframe via setParameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,35 +527,69 @@ partial interface RTCRtpTransceiver {
       </dl>
     </section>
   </section>
-  <section id="rtcrtpencodingparameters-video-keyframe">
+  <section id="rtcrtpsender-setparameters-keyframe">
     <h3>
-      RTCRtpEncodingParameters extensions for requesting the generation of a key frame.
+      {{RTCRtpSender}} {{RTCRtpSender/setParameters()}} extensions for requesting the generation of a key frame.
     </h3>
     <p>
-      The {{RTCRtpEncodingParameters}} dictionary is defined in
-      [[WEBRTC]]. This document extends that dictionary with
-      additional members to request generation of a key frame by the encoder.
+      The {{RTCRtpSender}}'s {{RTCRtpSender/setParameters()}} method is defined in
+      [[WEBRTC]]. This document extends it with an optional second argument
+      to request generation of a key frame by the encoder.
     </p>
-    <pre class="idl">partial dictionary RTCRtpEncodingParameters {
-  boolean requestKeyframe = false;
+    <pre class="idl">dictionary RTCEncodeOptions {
+  boolean keyFrame = false;
 };</pre>
-    <section id="rtcrtpencodingparameters-video-keyframe-attributes">
-      <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
-      <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for="RTCRtpEncodingParameters" class="dictionary-members"></dl>
+    <section id="rtcrtpsender-setparameters-keyframe-idl">
+      <h2>Dictionary {{RTCEncodeOptions}} Members</h2>
+      <p>
+        RTCEncodeOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
+      </p>
+      <dl data-link-for="RTCEncodeOptions" data-dfn-for="RTCEncodeOptions" class="dictionary-members"></dl>
         <dt>
-          <dfn data-idl>requestKeyframe</dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.
+          <dfn data-idl>keyFrame</dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.
         </dt>
         <dd>
           <p>
             When set to true, request that RTCRtpSender's encoder generates a keyframe for the encoding.
             The semantics of flag is similar to the RTCP FIR message described in [RFC5104], section 3.5.1.
           </p>
-          <p>
-            In the steps to call the {{RTCRtpSender/setParameters()}} method modify the step to validate parameters and
-            remove {{requestKeyframe}} if [= transceiver kind =] is `"audio"`.
-          </p>
         </dd>
       </dl>
+    </section>
+    <section id="rtcrtpsender-setparameters-keyframe-interface-extensions">
+      <h2>{{RTCRtpSender}} {{RTCRtpSender/setParameters()}} extensions</h2>
+      <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window]
+partial interface RTCRtpSender {
+    Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters,
+        optional sequence&lt;RTCEncodeOptions&gt; encodeOptions = []);
+};</pre>
+      <p>
+        In the steps to call the {{RTCRtpSender/setParameters()}} method,
+        let <var>parameters</var> be the method's first argument and let <var>encodeOptions</var>
+        be the method's second argument.
+      </p>
+      <p>
+        If the [=RTCRtpTransceiver/transceiver kind=] of the associated kind is `"audio"`, set
+        <var>encodeOptions</var> to the empty list.
+      </p>
+      <p>
+        Append the following step after the steps to validate the <var>parameters</var>:
+        <ul>
+          <li>If <var>encodeOptions</var> is not empty and <code><var>encodeOptions</var>.length</code>
+            is different from <code><var>parameters</var>.encodings.length</code>,
+            return a promise [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</li>
+        </ul>
+      </p>
+      <p>
+        In the steps to configure the media stack to use <var>parameters</var>, append the following step:
+        <ul>
+          <li>For the <var>encodeOption</var> at index <var>i</var>, request that the encoder associated with
+            <code><var>parameters</var>.encodings[i]</code> generates a key frame.</li>
+        </ul>
+      </p>
+      <p class="note">
+        The request to generate does not wait for a key frame to be produced by the encoder.
+      </p>
     </section>
   </section>
   <section id="rtcrtpcontributingsource-extensions">

--- a/index.html
+++ b/index.html
@@ -585,7 +585,6 @@ partial interface RTCRtpSender {
           <li>For the <var>encodeOption</var> at index <var>i</var>, request that the encoder associated with
             <code><var>parameters</var>.encodings[i]</code> generates a key frame.</li>
         </ul>
-      </p>
       <p class="note">
         The request to generate does not wait for a key frame to be produced by the encoder.
       </p>

--- a/index.html
+++ b/index.html
@@ -548,7 +548,7 @@ dictionary RTCEncodeOptions {
       <p>
         The {{RTCSetParameterOptions}} are extended by a sequence of {{RTCEncodeOptions}}, one for each encoding.
       </p>
-      <dl data-link-for="RTCSetParameterOptions" data-dfn-for="RTCSetParameterOptions" class="dictionary-members"></dl>
+      <dl data-link-for="RTCSetParameterOptions" data-dfn-for="RTCSetParameterOptions" class="dictionary-members">
         <dt>
           <dfn data-idl>encodeOptions</dfn> of type <span class="idlMemberType">sequence&lt;{{RTCEncodeOptions}}&gt;</span>, defaulting to <code>[]</code>.
         </dt>

--- a/index.html
+++ b/index.html
@@ -562,7 +562,7 @@ dictionary RTCEncodingOptions {
     <section id="rtcrtpsender-setparameters-keyframe-encodingoptions-idl">
       <h2>Dictionary {{RTCEncodingOptions}} Members</h2>
       <p>
-        RTCEncodingOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
+        {{RTCEncodingOptions}} is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
       </p>
       <dl data-link-for="RTCEncodingOptions" data-dfn-for="RTCEncodingOptions" class="dictionary-members">
         <dt>

--- a/index.html
+++ b/index.html
@@ -558,7 +558,7 @@ partial interface RTCRtpTransceiver {
     </section>
     <section id="rtcrtpsender-setparameters-keyframe-interface-extensions">
       <h2>{{RTCRtpSender}} {{RTCRtpSender/setParameters()}} extensions</h2>
-      <pre class="idl" data-tests="idlharness.https.window.js">[Exposed=Window]
+      <pre class="idl">[Exposed=Window]
 partial interface RTCRtpSender {
     Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters,
         optional sequence&lt;RTCEncodeOptions&gt; encodeOptions = []);

--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@ dictionary RTCEncodeOptions {
         <dd>
           <p>
             When set to true, request that RTCRtpSender's encoder generates a keyframe for the encoding.
-            The semantics of the option is similar to the RTCP FIR message described in [RFC5104], section 3.5.1.
+            The semantic of this boolean is similar to the RTCP FIR message described in [RFC5104], section 3.5.1.
           </p>
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@ dictionary RTCEncodeOptions {
         <dd>
           <p>
             When set to true, request that RTCRtpSender's encoder generates a keyframe for the encoding.
-            The semantics of flag is similar to the RTCP FIR message described in [RFC5104], section 3.5.1.
+            The semantics of the option is similar to the RTCP FIR message described in [RFC5104], section 3.5.1.
           </p>
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -577,33 +577,32 @@ dictionary RTCEncodeOptions {
       </dl>
     </section>
     <section id="rtcrtpsender-setparameters-keyframe-interface-extensions">
-      <h2>{{RTCRtpSender}} {{RTCRtpSender/setParameters()}} extensions</h2>
+      <h2>{{RTCRtpSender}} {{RTCRtpSender/setParameters()}} modifications to existing procedures</h2>
       <p>
         In the steps to call the {{RTCRtpSender/setParameters()}} method,
         let <var>parameters</var> be the method's first argument and let
         <var>setParameterOptions</var> be the method's second argument.
       </p>
-      <p>
-        If the [=RTCRtpTransceiver/transceiver kind=] of the associated kind is `"audio"`, set
-        <var>setParameterOptions.encodeOptions</var> to the empty list.
-      </p>
-      <p>
-        Append the following step after the steps to validate the <var>parameters</var>:
-        <ul>
-          <li>If <var>setParameterOptions.encodeOptions</var> is not empty and
-            <code><var>setParameterOptions.encodeOptions</var>.length</code> is
-            different from <code><var>parameters</var>.encodings.length</code>,
-            return a promise [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</li>
-        </ul>
-      </p>
-      <p>
-        In the steps to configure the media stack to use <var>parameters</var>, append the following step:
-        <ul>
-          <li>For each <var>setParameterOptions.encodeOptions</var> indexed by <var>i</var>,
-            if the <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> flag is set to <var>true</var>,
-            request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</li>
-        </ul>
-      </p>
+      <p>Append the following step after the steps to validate the <var>parameters</var>:</p>
+      <ul>
+        <li>
+          <p>If the [=RTCRtpTransceiver/transceiver kind=] of the associated kind is `"audio"`, set
+          <var>setParameterOptions.encodeOptions</var> to the empty list.</p>
+        </li>
+        <li>
+          <p>If <var>setParameterOptions.encodeOptions</var> is not empty and
+          <code><var>setParameterOptions.encodeOptions</var>.length</code> is
+          different from <code><var>parameters</var>.encodings.length</code>,
+          return a promise [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</p>
+        </li>
+      </ul>
+      <p>In the steps to configure the media stack to use <var>parameters</var>, append the following step:</p>
+      <ul>
+        <li><p>For each <var>setParameterOptions.encodeOptions</var> indexed by <var>i</var>,
+          if the <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> flag is set to <var>true</var>,
+          request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</p>
+        </li>
+      </ul>
       <p class="note">
         setParameters to generate does not wait for a key frame to be produced by the encoder.
       </p>

--- a/index.html
+++ b/index.html
@@ -579,7 +579,6 @@ partial interface RTCRtpSender {
             is different from <code><var>parameters</var>.encodings.length</code>,
             return a promise [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</li>
         </ul>
-      </p>
       <p>
         In the steps to configure the media stack to use <var>parameters</var>, append the following step:
         <ul>

--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@ partial interface RTCRtpTransceiver {
       <p>
         RTCEncodeOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
       </p>
-      <dl data-link-for="RTCEncodeOptions" data-dfn-for="RTCEncodeOptions" class="dictionary-members"></dl>
+      <dl data-link-for="RTCEncodeOptions" data-dfn-for="RTCEncodeOptions" class="dictionary-members">
         <dt>
           <dfn data-idl>keyFrame</dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.
         </dt>

--- a/index.html
+++ b/index.html
@@ -559,7 +559,7 @@ dictionary RTCEncodingOptions {
         </dd>
       </dl>
     </section>
-    <section id="rtcrtpsender-setparameters-keyframe-encodeoptions-idl">
+    <section id="rtcrtpsender-setparameters-keyframe-encodingoptions-idl">
       <h2>Dictionary {{RTCEncodingOptions}} Members</h2>
       <p>
         RTCEncodingOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@ partial interface RTCRtpTransceiver {
             The semantics of flag is similar to the RTCP FIR message described in [RFC5104], section 3.5.1.
           </p>
           <p>
-            In the steps to call the {{setParameters}} method modify the step to validate parameters and
+            In the steps to call the {{RTCRtpSender/setParameters()}} method modify the step to validate parameters and
             remove {{requestKeyframe}} if [= transceiver kind =] is `"audio"`.
           </p>
         </dd>

--- a/index.html
+++ b/index.html
@@ -527,6 +527,37 @@ partial interface RTCRtpTransceiver {
       </dl>
     </section>
   </section>
+  <section id="rtcrtpencodingparameters-video-keyframe">
+    <h3>
+      RTCRtpEncodingParameters extensions for requesting the generation of a key frame.
+    </h3>
+    <p>
+      The {{RTCRtpEncodingParameters}} dictionary is defined in
+      [[WEBRTC]]. This document extends that dictionary with
+      additional members to request generation of a key frame by the encoder.
+    </p>
+    <pre class="idl">partial dictionary RTCRtpEncodingParameters {
+  boolean requestKeyframe = false;
+};</pre>
+    <section id="rtcrtpencodingparameters-video-keyframe-attributes">
+      <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
+      <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for="RTCRtpEncodingParameters" class="dictionary-members"></dl>
+        <dt>
+          <dfn data-idl>requestKeyframe</dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.
+        </dt>
+        <dd>
+          <p>
+            When set to true, request that RTCRtpSender's encoder generates a keyframe for the encoding.
+            The semantics of flag is similar to the RTCP FIR message described in [RFC5104], section 3.5.1.
+          </p>
+          <p>
+            In the steps to call the {{setParameters}} method modify the step to validate parameters and
+            remove {{requestKeyframe}} if [= transceiver kind =] is `"audio"`.
+          </p>
+        </dd>
+      </dl>
+    </section>
+  </section>
   <section id="rtcrtpcontributingsource-extensions">
     <h3>
       {{RTCRtpContributingSource}} extensions

--- a/index.html
+++ b/index.html
@@ -537,7 +537,7 @@ partial interface RTCRtpTransceiver {
       generation of a key frame by the encoder.
     </p>
     <pre class="idl">partial dictionary RTCSetParameterOptions {
-  sequence&lt;RTCEncodingOptions&gt; encodeOptions = [];
+  sequence&lt;RTCEncodingOptions&gt; encodingOptions = [];
 };
 
 dictionary RTCEncodingOptions {

--- a/index.html
+++ b/index.html
@@ -583,7 +583,7 @@ dictionary RTCEncodeOptions {
         let <var>parameters</var> be the method's first argument and let
         <var>setParameterOptions</var> be the method's second argument.
       </p>
-      <p>Append the following step after the steps to validate the <var>parameters</var>:</p>
+      <p>Append the following steps after the steps to validate the <var>parameters</var>:</p>
       <ul>
         <li>
           <p>If the [=RTCRtpTransceiver/transceiver kind=] of the associated kind is `"audio"`, set
@@ -598,13 +598,14 @@ dictionary RTCEncodeOptions {
       </ul>
       <p>In the steps to configure the media stack to use <var>parameters</var>, append the following step:</p>
       <ul>
-        <li><p>For each <var>setParameterOptions.encodeOptions</var> indexed by <var>i</var>,
+        <li>
+          <p>For each <var>setParameterOptions.encodeOptions</var> indexed by <var>i</var>,
           if the <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> flag is set to <var>true</var>,
           request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</p>
         </li>
       </ul>
       <p class="note">
-        setParameters to generate does not wait for a key frame to be produced by the encoder.
+        setParameters does not wait for a key frame to be produced by the encoder.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -537,20 +537,20 @@ partial interface RTCRtpTransceiver {
       generation of a key frame by the encoder.
     </p>
     <pre class="idl">partial dictionary RTCSetParameterOptions {
-  sequence&lt;RTCEncodeOptions&gt; encodeOptions = [];
+  sequence&lt;RTCEncodingOptions&gt; encodeOptions = [];
 };
 
-dictionary RTCEncodeOptions {
+dictionary RTCEncodingOptions {
   boolean keyFrame = false;
 };</pre>
     <section id="rtcrtpsender-setparameters-keyframe-setparameteroptions-idl">
       <h2>Dictionary {{RTCSetParameterOptions}} Members</h2>
       <p>
-        The {{RTCSetParameterOptions}} are extended by a sequence of {{RTCEncodeOptions}}, one for each encoding.
+        The {{RTCSetParameterOptions}} are extended by a sequence of {{RTCEncodingOptions}}, one for each encoding.
       </p>
       <dl data-link-for="RTCSetParameterOptions" data-dfn-for="RTCSetParameterOptions" class="dictionary-members">
         <dt>
-          <dfn data-idl>encodeOptions</dfn> of type <span class="idlMemberType">sequence&lt;{{RTCEncodeOptions}}&gt;</span>, defaulting to <code>[]</code>.
+          <dfn data-idl>encodingOptions</dfn> of type <span class="idlMemberType">sequence&lt;{{RTCEncodingOptions}}&gt;</span>, defaulting to <code>[]</code>.
         </dt>
         <dd>
           <p>
@@ -560,11 +560,11 @@ dictionary RTCEncodeOptions {
       </dl>
     </section>
     <section id="rtcrtpsender-setparameters-keyframe-encodeoptions-idl">
-      <h2>Dictionary {{RTCEncodeOptions}} Members</h2>
+      <h2>Dictionary {{RTCEncodingOptions}} Members</h2>
       <p>
-        RTCEncodeOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
+        RTCEncodingOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
       </p>
-      <dl data-link-for="RTCEncodeOptions" data-dfn-for="RTCEncodeOptions" class="dictionary-members">
+      <dl data-link-for="RTCEncodingOptions" data-dfn-for="RTCEncodingOptions" class="dictionary-members">
         <dt>
           <dfn data-idl>keyFrame</dfn> of type <span class="idlMemberType">boolean</span>, defaulting to <code>false</code>.
         </dt>

--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@ dictionary RTCEncodeOptions {
       <ul>
         <li>
           <p>For each <var>setParameterOptions.encodeOptions</var> indexed by <var>i</var>,
-          if the <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> flag is set to <var>true</var>,
+          if <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> is set to <var>true</var>,
           request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</p>
         </li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -605,7 +605,7 @@ dictionary RTCEncodeOptions {
         </li>
       </ul>
       <p class="note">
-        setParameters does not wait for a key frame to be produced by the encoder.
+        {{RTCRtpSender/setParameters()}} does not wait for a key frame to be produced by the encoder.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -595,6 +595,7 @@ dictionary RTCEncodeOptions {
             different from <code><var>parameters</var>.encodings.length</code>,
             return a promise [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</li>
         </ul>
+      </p>
       <p>
         In the steps to configure the media stack to use <var>parameters</var>, append the following step:
         <ul>
@@ -602,6 +603,7 @@ dictionary RTCEncodeOptions {
             if the <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> flag is set to <var>true</var>,
             request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</li>
         </ul>
+      </p>
       <p class="note">
         setParameters to generate does not wait for a key frame to be produced by the encoder.
       </p>

--- a/index.html
+++ b/index.html
@@ -533,13 +533,33 @@ partial interface RTCRtpTransceiver {
     </h3>
     <p>
       The {{RTCRtpSender}}'s {{RTCRtpSender/setParameters()}} method is defined in
-      [[WEBRTC]]. This document extends it with an optional second argument
-      to request generation of a key frame by the encoder.
+      [[WEBRTC]]. This document extends the optional second argument to request
+      generation of a key frame by the encoder.
     </p>
-    <pre class="idl">dictionary RTCEncodeOptions {
+    <pre class="idl">partial dictionary RTCSetParameterOptions {
+  sequence&lt;RTCEncodeOptions&gt; encodeOptions = [];
+};
+
+dictionary RTCEncodeOptions {
   boolean keyFrame = false;
 };</pre>
-    <section id="rtcrtpsender-setparameters-keyframe-idl">
+    <section id="rtcrtpsender-setparameters-keyframe-setparameteroptions-idl">
+      <h2>Dictionary {{RTCSetParameterOptions}} Members</h2>
+      <p>
+        The {{RTCSetParameterOptions}} are extended by a sequence of {{RTCEncodeOptions}}, one for each encoding.
+      </p>
+      <dl data-link-for="RTCSetParameterOptions" data-dfn-for="RTCSetParameterOptions" class="dictionary-members"></dl>
+        <dt>
+          <dfn data-idl>encodeOptions</dfn> of type <span class="idlMemberType">sequence&lt;{{RTCEncodeOptions}}&gt;</span>, defaulting to <code>[]</code>.
+        </dt>
+        <dd>
+          <p>
+            A sequence containing encoding options for each RTP encoding.
+          </p>
+        </dd>
+      </dl>
+    </section>
+    <section id="rtcrtpsender-setparameters-keyframe-encodeoptions-idl">
       <h2>Dictionary {{RTCEncodeOptions}} Members</h2>
       <p>
         RTCEncodeOptions is the WebRTC equivalent of {{VideoEncoderEncodeOptions}} in [[WebCodecs]].
@@ -558,35 +578,32 @@ partial interface RTCRtpTransceiver {
     </section>
     <section id="rtcrtpsender-setparameters-keyframe-interface-extensions">
       <h2>{{RTCRtpSender}} {{RTCRtpSender/setParameters()}} extensions</h2>
-      <pre class="idl">[Exposed=Window]
-partial interface RTCRtpSender {
-    Promise&lt;undefined&gt; setParameters(RTCRtpSendParameters parameters,
-        optional sequence&lt;RTCEncodeOptions&gt; encodeOptions = []);
-};</pre>
       <p>
         In the steps to call the {{RTCRtpSender/setParameters()}} method,
-        let <var>parameters</var> be the method's first argument and let <var>encodeOptions</var>
-        be the method's second argument.
+        let <var>parameters</var> be the method's first argument and let
+        <var>setParameterOptions</var> be the method's second argument.
       </p>
       <p>
         If the [=RTCRtpTransceiver/transceiver kind=] of the associated kind is `"audio"`, set
-        <var>encodeOptions</var> to the empty list.
+        <var>setParameterOptions.encodeOptions</var> to the empty list.
       </p>
       <p>
         Append the following step after the steps to validate the <var>parameters</var>:
         <ul>
-          <li>If <var>encodeOptions</var> is not empty and <code><var>encodeOptions</var>.length</code>
-            is different from <code><var>parameters</var>.encodings.length</code>,
+          <li>If <var>setParameterOptions.encodeOptions</var> is not empty and
+            <code><var>setParameterOptions.encodeOptions</var>.length</code> is
+            different from <code><var>parameters</var>.encodings.length</code>,
             return a promise [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</li>
         </ul>
       <p>
         In the steps to configure the media stack to use <var>parameters</var>, append the following step:
         <ul>
-          <li>For the <var>encodeOption</var> at index <var>i</var>, request that the encoder associated with
-            <code><var>parameters</var>.encodings[i]</code> generates a key frame.</li>
+          <li>For each <var>setParameterOptions.encodeOptions</var> indexed by <var>i</var>,
+            if the <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> flag is set to <var>true</var>,
+            request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</li>
         </ul>
       <p class="note">
-        The request to generate does not wait for a key frame to be produced by the encoder.
+        setParameters to generate does not wait for a key frame to be produced by the encoder.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -587,11 +587,11 @@ dictionary RTCEncodingOptions {
       <ul>
         <li>
           <p>If the [=RTCRtpTransceiver/transceiver kind=] of the associated kind is `"audio"`, set
-          <var>setParameterOptions.encodeOptions</var> to the empty list.</p>
+          <var>setParameterOptions.encodingOptions</var> to the empty list.</p>
         </li>
         <li>
-          <p>If <var>setParameterOptions.encodeOptions</var> is not empty and
-          <code><var>setParameterOptions.encodeOptions</var>.length</code> is
+          <p>If <var>setParameterOptions.encodingOptions</var> is not empty and
+          <code><var>setParameterOptions.encodingOptions</var>.length</code> is
           different from <code><var>parameters</var>.encodings.length</code>,
           return a promise [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</p>
         </li>
@@ -599,8 +599,8 @@ dictionary RTCEncodingOptions {
       <p>In the steps to configure the media stack to use <var>parameters</var>, append the following step:</p>
       <ul>
         <li>
-          <p>For each <var>setParameterOptions.encodeOptions</var> indexed by <var>i</var>,
-          if <code><var>setParameterOptions.encodeOptions</var>[i].keyFrame</code> is set to <var>true</var>,
+          <p>For each <var>setParameterOptions.encodingOptions</var> indexed by <var>i</var>,
+          if <code><var>setParameterOptions.encodingOptions</var>[i].keyFrame</code> is set to <var>true</var>,
           request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</p>
         </li>
       </ul>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-extensions/issues/158

use setParameters() which is often used in situations that may yield a key frame such as resizing the video.

The semantic of that flag is the same as the RTCP FIR semantics from
  https://www.rfc-editor.org/rfc/rfc5104#section-3.5.1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-extensions/pull/167.html" title="Last updated on Jul 27, 2023, 2:42 PM UTC (7ce6e53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/167/fa46b8c...fippo:7ce6e53.html" title="Last updated on Jul 27, 2023, 2:42 PM UTC (7ce6e53)">Diff</a>