### PR TITLE
Prevent candidate pair removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,22 +750,22 @@ dictionary RTCEncodingOptions {
     </ol>
     <pre class="idl">
       partial interface RTCIceTransport {
-        attribute EventHandler oncandidatepairadded;
+        attribute EventHandler onicecandidatepair;
         attribute EventHandler onicecandidatepairprune;
       };</pre>
     <section>
       <h2>Attributes</h2>
       <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="attributes">
         <dt>
-          <dfn>oncandidatepairadded</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          <dfn>onicecandidatepair</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
         </dt>
         <dd>
           <p>
-            The event type of this event handler is {{candidatepairadded}}.
+            The event type of this event handler is {{icecandidatepair}}.
           </p>
           <p>
             When the [= ICE agent =] has formed a candidate pair, the [= user agent =] MUST queue a task to [= fire an
-            event =] named {{candidatepairadded}} using the {{RTCIceCandidatePairEvent}} interface with the
+            event =] named {{icecandidatepair}} using the {{RTCIceCandidatePairEvent}} interface with the
             {{RTCIceCandidatePairEvent/candidatePair}} attribute set to the formed candidate pair.
           </p>
         </dd>
@@ -788,7 +788,7 @@ dictionary RTCEncodingOptions {
         <dfn>RTCIceCandidatePairEvent</dfn>
       </h2>
       <p>
-        The {{RTCIceTransport/candidatepairadded}} and {{RTCIceTransport/icecandidatepairprune}} events use the {{RTCIceCandidatePairEvent}} interface.
+        The {{RTCIceTransport/icecandidatepair}} and {{RTCIceTransport/icecandidatepairprune}} events use the {{RTCIceCandidatePairEvent}} interface.
       </p>
       <div>
         <pre class="idl">[Exposed=Window]
@@ -1265,7 +1265,7 @@ partial interface RTCRtpTransceiver {
       </thead>
       <tbody>
         <tr>
-          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>candidatepairadded</dfn></th>
+          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>icecandidatepair</dfn></th>
           <td>{{RTCIceCandidatePairEvent}}</td>
           <td>
             The [= ICE agent =] has formed a candidate pair and is making it available to the script.

--- a/index.html
+++ b/index.html
@@ -57,9 +57,9 @@
       <a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time"><dfn>RTP Header Extension for Absolute Capture Time</dfn></a>:
     </p>
     <ul>
-      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#absolute-capture-timestamp"><dfn>absolute capture timestamp</dfn></a>
-      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#timestamp-interpolation"><dfn>timestamp interpolation</dfn></a>
-      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#estimated-capture-clock-offset"><dfn>estimated capture clock offset</dfn></a>
+      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#absolute-capture-timestamp"><dfn>absolute capture timestamp</dfn></a></li>
+      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#timestamp-interpolation"><dfn>timestamp interpolation</dfn></a></li>
+      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#estimated-capture-clock-offset"><dfn>estimated capture clock offset</dfn></a></li>
     </ul>
     <p>The process of <dfn>chaining</dfn> an operation to an <dfn>operations chain</dfn> is defined in [[WEBRTC]] Section 4.4.1.2.</p>
     <p>

--- a/index.html
+++ b/index.html
@@ -733,8 +733,7 @@ dictionary RTCEncodingOptions {
         <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/icecandidatepairprune}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
-          {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/candidatePair}}
-          attribute initialized to |candidatePair|.
+          {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of |candidatePair|.
         </p>
       </li>
       <li>
@@ -765,8 +764,8 @@ dictionary RTCEncodingOptions {
           </p>
           <p>
             When the [= ICE agent =] has formed a candidate pair, the [= user agent =] MUST queue a task to [= fire an
-            event =] named {{icecandidatepair}} using the {{RTCIceCandidatePairEvent}} interface with the
-            {{RTCIceCandidatePairEvent/candidatePair}} attribute set to the formed candidate pair.
+            event =] named {{icecandidatepair}} using the {{RTCIceCandidatePairEvent}} interface, with the
+            {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes set to the local and remote candidates, respectively, of the formed candidate pair.
           </p>
         </dd>
         <dt>
@@ -794,7 +793,8 @@ dictionary RTCEncodingOptions {
         <pre class="idl">[Exposed=Window]
 interface RTCIceCandidatePairEvent : Event {
   constructor(DOMString type, RTCIceCandidatePairEventInit eventInitDict);
-  readonly attribute RTCIceCandidatePair candidatePair;
+  readonly attribute RTCIceCandidate local;
+  readonly attribute RTCIceCandidate remote;
 };</pre>
         <section>
           <h4>Constructors</h4>
@@ -807,11 +807,19 @@ interface RTCIceCandidatePairEvent : Event {
           <h4>Attributes</h4>
           <dl data-link-for="RTCIceCandidatePairEvent" data-dfn-for="RTCIceCandidatePairEvent" class="attributes">
             <dt>
-              <dfn>candidatePair</dfn> of type <span class="idlAttrType">{{RTCIceCandidatePair}}</span>, readonly
+              <dfn>local</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, readonly
             </dt>
             <dd>
               <p>
-                The {{candidatePair}} attribute represents the {{RTCIceCandidatePair}} object associated with the event.
+                The {{local}} attribute represents the local {{RTCIceCandidate}} of the candidate pair associated with the event.
+              </p>
+            </dd>
+            <dt>
+              <dfn>remote</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The {{remote}} attribute represents the remote {{RTCIceCandidate}} of the candidate pair associated with the event.
               </p>
             </dd>
           </dl>
@@ -820,18 +828,27 @@ interface RTCIceCandidatePairEvent : Event {
       <div>
         <pre class="idl">
 dictionary RTCIceCandidatePairEventInit : EventInit {
-  required RTCIceCandidatePair candidatePair;
+  required RTCIceCandidate local;
+  required RTCIceCandidate remote;
 };</pre>
         <section id="rtcicecandidatepaireventinit">
           <h4>Dictionary <dfn>RTCIceCandidatePairEventInit</dfn> Members</h4>
           <dl data-link-for="RTCIceCandidatePairEventInit" data-dfn-for="RTCIceCandidatePairEventInit"
             class="dictionary-members">
             <dt>
-              <dfn>candidatePair</dfn> of type <span class="idlAttrType">{{RTCIceCandidatePair}}</span>, required
+              <dfn>local</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, required
             </dt>
             <dd>
               <p>
-                The {{RTCIceCandidatePair}} object announced by the event.
+                The local {{RTCIceCandidate}} of the candidate pair announced by the event.
+              </p>
+            </dd>
+            <dt>
+              <dfn>remote</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, required
+            </dt>
+            <dd>
+              <p>
+                The remote {{RTCIceCandidate}} of the candidate pair announced by the event.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -705,7 +705,7 @@ dictionary RTCEncodingOptions {
       application to observe and affect certain actions that an <dfn>ICE agent</dfn> [[RFC5245]] performs.
     </p>
     <p>
-      When the [= ICE agent =] has selected a candidate pair to prune, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-propose-prune">propose a candidate pair pruning</dfn>:
+      When the [= ICE agent =] has selected a candidate pair to prune, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-prune">prune a candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -726,13 +726,13 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |candidatePair:RTCIceCandidatePair| be the candidate pair which is being proposed for pruning.
+          Let |candidatePair:RTCIceCandidatePair| be the candidate pair which is being pruned.
         </p>
       </li>
       <li>
         <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
-          {{RTCIceTransport/candidatepairpruneproposed}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
+          {{RTCIceTransport/icecandidatepairprune}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
           {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/candidatePair}}
           attribute initialized to |candidatePair|.
         </p>
@@ -751,7 +751,7 @@ dictionary RTCEncodingOptions {
     <pre class="idl">
       partial interface RTCIceTransport {
         attribute EventHandler oncandidatepairadded;
-        attribute EventHandler oncandidatepairpruneproposed;
+        attribute EventHandler onicecandidatepairprune;
       };</pre>
     <section>
       <h2>Attributes</h2>
@@ -770,15 +770,15 @@ dictionary RTCEncodingOptions {
           </p>
         </dd>
         <dt>
-          <dfn>oncandidatepairpruneproposed</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          <dfn>onicecandidatepairprune</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
         </dt>
         <dd>
           <p>
-            The event type of this event handler is {{candidatepairpruneproposed}}.
+            The event type of this event handler is {{icecandidatepairprune}}.
           </p>
           <p>
             When the [= ICE agent =] has selected a candidate pair to prune, but before the pruning has actually occurred,
-            the [= user agent =] MUST [= propose a candidate pair pruning =].
+            the [= user agent =] MUST run the steps to [= prune a candidate pair =].
           </p>
         </dd>
       </dl>
@@ -788,7 +788,7 @@ dictionary RTCEncodingOptions {
         <dfn>RTCIceCandidatePairEvent</dfn>
       </h2>
       <p>
-        The {{RTCIceTransport/candidatepairadded}} and {{RTCIceTransport/candidatepairpruneproposed}} events use the {{RTCIceCandidatePairEvent}} interface.
+        The {{RTCIceTransport/candidatepairadded}} and {{RTCIceTransport/icecandidatepairprune}} events use the {{RTCIceCandidatePairEvent}} interface.
       </p>
       <div>
         <pre class="idl">[Exposed=Window]
@@ -1272,10 +1272,10 @@ partial interface RTCRtpTransceiver {
           </td>
         </tr>
         <tr>
-          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>candidatepairpruneproposed</dfn></th>
+          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>icecandidatepairprune</dfn></th>
           <td>{{RTCIceCandidatePairEvent}}</td>
           <td>
-            The [= ICE agent =] has selected a candidate pair to prune, but the pruning has not yet occurred.
+            The [= ICE agent =] has selected a candidate pair to prune, which will be pruned unless the operation is canceled by invoking the <code>preventDefault()</code> method on the event.
           </td>
         </tr>
       </tbody>

--- a/index.html
+++ b/index.html
@@ -705,14 +705,6 @@ dictionary RTCEncodingOptions {
       application to observe and affect certain actions that an <dfn>ICE agent</dfn> [[RFC5245]] performs.
     </p>
     <p>
-      Add the following internal slots to the {{RTCIceTransport}} object:
-    </p>
-    <ul>
-      <li>
-        <dfn class=export data-dfn-for="RTCIceTransport">[[\ProposalPending]]</dfn> initialized to <code>false</code>.
-      </li>
-    </ul>
-    <p>
       When the [= ICE agent =] has selected a candidate pair to prune, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-propose-prune">propose a candidate pair pruning</dfn>:
     </p>
     <ol class="algorithm">
@@ -739,20 +731,10 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>true</code>.
-        </p>
-      </li>
-      <li>
-        <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/candidatepairpruneproposed}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
           {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/candidatePair}}
           attribute initialized to |candidatePair|.
-        </p>
-      </li>
-      <li>
-        <p>
-          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>false</code>.
         </p>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -750,11 +750,25 @@ dictionary RTCEncodingOptions {
     </ol>
     <pre class="idl">
       partial interface RTCIceTransport {
+        attribute EventHandler oncandidatepairadded;
         attribute EventHandler oncandidatepairpruneproposed;
       };</pre>
     <section>
       <h2>Attributes</h2>
       <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="attributes">
+        <dt>
+          <dfn>oncandidatepairadded</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+        </dt>
+        <dd>
+          <p>
+            The event type of this event handler is {{candidatepairadded}}.
+          </p>
+          <p>
+            When the [= ICE agent =] has formed a candidate pair, the [= user agent =] MUST queue a task to [= fire an
+            event =] named {{candidatepairadded}} using the {{RTCIceCandidatePairEvent}} interface with the
+            {{RTCIceCandidatePairEvent/candidatePair}} attribute set to the formed candidate pair.
+          </p>
+        </dd>
         <dt>
           <dfn>oncandidatepairpruneproposed</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
         </dt>
@@ -774,7 +788,7 @@ dictionary RTCEncodingOptions {
         <dfn>RTCIceCandidatePairEvent</dfn>
       </h2>
       <p>
-        The {{RTCIceTransport/candidatepairpruneproposed}} event uses the {{RTCIceCandidatePairEvent}} interface.
+        The {{RTCIceTransport/candidatepairadded}} and {{RTCIceTransport/candidatepairpruneproposed}} events use the {{RTCIceCandidatePairEvent}} interface.
       </p>
       <div>
         <pre class="idl">[Exposed=Window]
@@ -1250,6 +1264,13 @@ partial interface RTCRtpTransceiver {
         </tr>
       </thead>
       <tbody>
+        <tr>
+          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>candidatepairadded</dfn></th>
+          <td>{{RTCIceCandidatePairEvent}}</td>
+          <td>
+            The [= ICE agent =] has formed a candidate pair and is making it available to the script.
+          </td>
+        </tr>
         <tr>
           <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>candidatepairpruneproposed</dfn></th>
           <td>{{RTCIceCandidatePairEvent}}</td>

--- a/index.html
+++ b/index.html
@@ -62,6 +62,18 @@
       <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#estimated-capture-clock-offset"><dfn>estimated capture clock offset</dfn></a>
     </ul>
     <p>The process of <dfn>chaining</dfn> an operation to an <dfn>operations chain</dfn> is defined in [[WEBRTC]] Section 4.4.1.2.</p>
+    <p>
+      The {{EventHandler}} interface, representing a callback used for event handlers, is defined in [[!HTML]].
+    </p>
+    <p>
+      The concepts [= queue a task =] and [= networking task source =] are defined in [[!HTML]].
+    </p>
+    <p>
+      The concept [= fire an event =] is defined in [[!DOM]].
+    </p>
+    <p>
+      The terms [= event =], [= event handlers =] and [= event handler event types =] are defined in [[!HTML]].
+    </p>
   </section>
   <section id="ice-csp">
     <h3>
@@ -684,6 +696,153 @@ dictionary RTCEncodingOptions {
       </p>
     </section>
   </section>
+  <section id="rtcicetransport">
+    <h3>
+      {{RTCIceTransport}} extensions
+    </h3>
+    <p>
+      The {{RTCIceTransport}} interface is defined in [[WEBRTC]]. This document extends that interface to allow an
+      application to observe and affect certain actions that an <dfn>ICE agent</dfn> [[RFC5245]] performs.
+    </p>
+    <p>
+      Add the following internal slots to the {{RTCIceTransport}} object:
+    </p>
+    <ul>
+      <li>
+        <dfn class=export data-dfn-for="RTCIceTransport">[[\ProposalPending]]</dfn> initialized to <code>false</code>.
+      </li>
+    </ul>
+    <p>
+      When the [= ICE agent =] has selected a candidate pair to prune, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-propose-prune">propose a candidate pair pruning</dfn>:
+    </p>
+    <ol class="algorithm">
+      <li>
+        <p>
+          Let |connection:RTCPeerConnection| be the {{RTCPeerConnection}} object associated with this [= ICE agent =].
+        </p>
+      </li>
+      <li>
+        <p>
+          If <var>connection</var>.{{RTCPeerConnection/[[IsClosed]]}} is
+          <code>true</code>, abort these steps.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |transport:RTCIceTransport| be the {{RTCIceTransport}} object associated with this candidate pair.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |candidatePair:RTCIceCandidatePair| be the candidate pair which is being proposed for pruning.
+        </p>
+      </li>
+      <li>
+        <p>
+          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>true</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
+          {{RTCIceTransport/candidatepairpruneproposed}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
+          {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/candidatePair}}
+          attribute initialized to |candidatePair|.
+        </p>
+      </li>
+      <li>
+        <p>
+          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not prune the candidate pair indicated by |candidatePair|, and instead continue to send and respond to ICE connectivity checks on the candidate pair as before.
+        </p>
+      </li>
+      <li>
+        <p>
+          Otherwise, instruct the [= ICE agent =] to prune the candidate pair indicated by |candidatePair|.
+        </p>
+      </li>
+    </ol>
+    <pre class="idl">
+      partial interface RTCIceTransport {
+        attribute EventHandler oncandidatepairpruneproposed;
+      };</pre>
+    <section>
+      <h2>Attributes</h2>
+      <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="attributes">
+        <dt>
+          <dfn>oncandidatepairpruneproposed</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+        </dt>
+        <dd>
+          <p>
+            The event type of this event handler is {{candidatepairpruneproposed}}.
+          </p>
+          <p>
+            When the [= ICE agent =] has selected a candidate pair to prune, but before the pruning has actually occurred,
+            the [= user agent =] MUST [= propose a candidate pair pruning =].
+          </p>
+        </dd>
+      </dl>
+    </section>
+    <section>
+      <h2>
+        <dfn>RTCIceCandidatePairEvent</dfn>
+      </h2>
+      <p>
+        The {{RTCIceTransport/candidatepairpruneproposed}} event uses the {{RTCIceCandidatePairEvent}} interface.
+      </p>
+      <div>
+        <pre class="idl">[Exposed=Window]
+interface RTCIceCandidatePairEvent : Event {
+  constructor(DOMString type, RTCIceCandidatePairEventInit eventInitDict);
+  readonly attribute RTCIceCandidatePair candidatePair;
+};</pre>
+        <section>
+          <h4>Constructors</h4>
+          <dl data-link-for="RTCIceCandidatePairEvent" data-dfn-for="RTCIceCandidatePairEvent" class="constructors">
+            <dt><dfn>RTCIceCandidatePairEvent.constructor()</dfn></dt>
+            <dd></dd>
+          </dl>
+        </section>
+        <section>
+          <h4>Attributes</h4>
+          <dl data-link-for="RTCIceCandidatePairEvent" data-dfn-for="RTCIceCandidatePairEvent" class="attributes">
+            <dt>
+              <dfn>candidatePair</dfn> of type <span class="idlAttrType">{{RTCIceCandidatePair}}</span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The {{candidatePair}} attribute represents the {{RTCIceCandidatePair}} object associated with the event.
+              </p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+      <div>
+        <pre class="idl">
+dictionary RTCIceCandidatePairEventInit : EventInit {
+  required RTCIceCandidatePair candidatePair;
+};</pre>
+        <section id="rtcicecandidatepaireventinit">
+          <h4>Dictionary <dfn>RTCIceCandidatePairEventInit</dfn> Members</h4>
+          <dl data-link-for="RTCIceCandidatePairEventInit" data-dfn-for="RTCIceCandidatePairEventInit"
+            class="dictionary-members">
+            <dt>
+              <dfn>candidatePair</dfn> of type <span class="idlAttrType">{{RTCIceCandidatePair}}</span>, required
+            </dt>
+            <dd>
+              <p>
+                The {{RTCIceCandidatePair}} object announced by the event.
+              </p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </section>
+  </section>
   <section id="rtcrtpcontributingsource-extensions">
     <h3>
       {{RTCRtpContributingSource}} extensions
@@ -1095,6 +1254,29 @@ partial interface RTCRtpTransceiver {
         is hardware-accelerated".
       </p>
     </section>
+  </section>
+  <section class="informative">
+    <h2>Event summary</h2>
+    <p>
+      The following events fire on {{RTCIceTransport}} objects:</p>
+    <table class="simple">
+      <thead>
+        <tr>
+          <th>Event name</th>
+          <th>Interface</th>
+          <th>Fired when...</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>candidatepairpruneproposed</dfn></th>
+          <td>{{RTCIceCandidatePairEvent}}</td>
+          <td>
+            The [= ICE agent =] has selected a candidate pair to prune, but the pruning has not yet occurred.
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </section>
   <section class="informative" id="security-considerations">
     <h2>

--- a/index.html
+++ b/index.html
@@ -705,7 +705,7 @@ dictionary RTCEncodingOptions {
       application to observe and affect certain actions that an <dfn>ICE agent</dfn> [[RFC5245]] performs.
     </p>
     <p>
-      When the [= ICE agent =] has selected a candidate pair to prune, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-prune">prune a candidate pair</dfn>:
+      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-remove">remove a candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -726,58 +726,63 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |candidatePair:RTCIceCandidatePair| be the candidate pair which is being pruned.
+          Let |candidatePair:RTCIceCandidatePair| be the candidate pair which is being removed.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |cancelable:boolean| be <code>true</code> if the candidate pair is being removed in order to free an unused candidate, and <code>false</code> otherwise.
         </p>
       </li>
       <li>
         <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
-          {{RTCIceTransport/icecandidatepairprune}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
-          {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of |candidatePair|.
+          {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
+          {{Event/cancelable}} attribute initialized to <var>cancelable</var>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of |candidatePair|.
         </p>
       </li>
       <li>
         <p>
-          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not prune the candidate pair indicated by |candidatePair|, and instead continue to send and respond to ICE connectivity checks on the candidate pair as before.
+          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not remove the candidate pair indicated by |candidatePair|, and instead continue to send and respond to ICE connectivity checks on the candidate pair as before.
         </p>
       </li>
       <li>
         <p>
-          Otherwise, instruct the [= ICE agent =] to prune the candidate pair indicated by |candidatePair|.
+          Otherwise, instruct the [= ICE agent =] to remove the candidate pair indicated by |candidatePair|.
         </p>
       </li>
     </ol>
     <pre class="idl">
       partial interface RTCIceTransport {
-        attribute EventHandler onicecandidatepair;
-        attribute EventHandler onicecandidatepairprune;
+        attribute EventHandler onicecandidatepairadd;
+        attribute EventHandler onicecandidatepairremove;
       };</pre>
     <section>
       <h2>Attributes</h2>
       <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="attributes">
         <dt>
-          <dfn>onicecandidatepair</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          <dfn>onicecandidatepairadd</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
         </dt>
         <dd>
           <p>
-            The event type of this event handler is {{icecandidatepair}}.
+            The event type of this event handler is {{icecandidatepairadd}}.
           </p>
           <p>
             When the [= ICE agent =] has formed a candidate pair, the [= user agent =] MUST queue a task to [= fire an
-            event =] named {{icecandidatepair}} using the {{RTCIceCandidatePairEvent}} interface, with the
+            event =] named {{icecandidatepairadd}} using the {{RTCIceCandidatePairEvent}} interface, with the
             {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes set to the local and remote candidates, respectively, of the formed candidate pair.
           </p>
         </dd>
         <dt>
-          <dfn>onicecandidatepairprune</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          <dfn>onicecandidatepairremove</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
         </dt>
         <dd>
           <p>
-            The event type of this event handler is {{icecandidatepairprune}}.
+            The event type of this event handler is {{icecandidatepairremove}}.
           </p>
           <p>
-            When the [= ICE agent =] has selected a candidate pair to prune, but before the pruning has actually occurred,
-            the [= user agent =] MUST run the steps to [= prune a candidate pair =].
+            When the [= ICE agent =] has picked a candidate pair to remove, but before the removal has actually occurred,
+            the [= user agent =] MUST run the steps to [= remove a candidate pair =].
           </p>
         </dd>
       </dl>
@@ -787,7 +792,7 @@ dictionary RTCEncodingOptions {
         <dfn>RTCIceCandidatePairEvent</dfn>
       </h2>
       <p>
-        The {{RTCIceTransport/icecandidatepair}} and {{RTCIceTransport/icecandidatepairprune}} events use the {{RTCIceCandidatePairEvent}} interface.
+        The {{RTCIceTransport/icecandidatepairadd}} and {{RTCIceTransport/icecandidatepairremove}} events use the {{RTCIceCandidatePairEvent}} interface.
       </p>
       <div>
         <pre class="idl">[Exposed=Window]
@@ -1282,17 +1287,17 @@ partial interface RTCRtpTransceiver {
       </thead>
       <tbody>
         <tr>
-          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>icecandidatepair</dfn></th>
+          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>icecandidatepairadd</dfn></th>
           <td>{{RTCIceCandidatePairEvent}}</td>
           <td>
             The [= ICE agent =] has formed a candidate pair and is making it available to the script.
           </td>
         </tr>
         <tr>
-          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>icecandidatepairprune</dfn></th>
+          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>icecandidatepairremove</dfn></th>
           <td>{{RTCIceCandidatePairEvent}}</td>
           <td>
-            The [= ICE agent =] has selected a candidate pair to prune, which will be pruned unless the operation is canceled by invoking the <code>preventDefault()</code> method on the event.
+            The [= ICE agent =] has picked a candidate pair to remove, and unless the operation is canceled by invoking the <code>preventDefault()</code> method on the event, it will be removed.
           </td>
         </tr>
       </tbody>

--- a/webrtc-extensions.js
+++ b/webrtc-extensions.js
@@ -5,7 +5,7 @@ var respecConfig = {
       repoURL: "https://github.com/w3c/webrtc-extensions/",
       branch: "main"
     },
-    "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "infra"],
+    "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "infra", "dom"],
     "shortName": "webrtc-extensions",
     "specStatus": "ED",
     "subjectPrefix": "[webrtc-extensions]",


### PR DESCRIPTION
Fixes #166 

This is a proposal for a cancelable event approach to preventing ICE candidate pair pruning.

An event is also proposed at the formation of candidate pairs, which is not strictly necessary for preventing candidate pair pruning, but makes sense to go together for applications to have a better view of the candidate pair lifecycle.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/168.html" title="Last updated on Sep 4, 2023, 2:22 PM UTC (9c3d3f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/168/9601ac8...sam-vi:9c3d3f0.html" title="Last updated on Sep 4, 2023, 2:22 PM UTC (9c3d3f0)">Diff</a>