### PR TITLE
Fix mistake in internal slot assignment for NegotiatedHeaderExtensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ partial interface RTCRtpTransceiver {
           9.1.</p>
         </li>
         <li>
-          <p>Set {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} to an empty
+          <p>Set {{RTCRtpTransceiver/[[NegotiatedHeaderExtensions]]}} to an empty
           list.</p>
         </li>
       </ol>


### PR DESCRIPTION
Previous description made no sense.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/169.html" title="Last updated on Jun 6, 2023, 8:54 AM UTC (e980f6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/169/51024d3...e980f6a.html" title="Last updated on Jun 6, 2023, 8:54 AM UTC (e980f6a)">Diff</a>