### PR TITLE
editorial: fix respec / validation woes

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,12 +55,12 @@
     <p>
       The following terms are defined in
       <a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time"><dfn>RTP Header Extension for Absolute Capture Time</dfn></a>:
-      <ul>
-        <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#absolute-capture-timestamp"><dfn>absolute capture timestamp</dfn></a>
-        <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#timestamp-interpolation"><dfn>timestamp interpolation</dfn></a>
-        <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#estimated-capture-clock-offset"><dfn>estimated capture clock offset</dfn></a>
-      </ul>
     </p>
+    <ul>
+      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#absolute-capture-timestamp"><dfn>absolute capture timestamp</dfn></a>
+      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#timestamp-interpolation"><dfn>timestamp interpolation</dfn></a>
+      <li><a href="https://webrtc.org/experiments/rtp-hdrext/abs-capture-time#estimated-capture-clock-offset"><dfn>estimated capture clock offset</dfn></a>
+    </ul>
     <p>The process of <dfn>chaining</dfn> an operation to an <dfn>operations chain</dfn> is defined in [[WEBRTC]] Section 4.4.1.2.</p>
   </section>
   <section id="ice-csp">
@@ -824,7 +824,6 @@ dictionary RTCEncodingOptions {
             {{RTCRtpContributingSource.timestamp}} -
             <var>receiverCaptureTimestamp</var>.
           </p>
-          </p>
         </dd>
       </dl>
     </section>
@@ -838,7 +837,7 @@ dictionary RTCEncodingOptions {
        Transferable Data Channels
      </h3>
      <p>This section extends {{RTCDataChannel}} by making it <a data-cite="!HTML/#transferable-objects">transferable</a>.</p>
-      This allows sending and receiving messages outside the context the connection was created, for instance in workers or third-party iframes.</p>
+     <p>This allows sending and receiving messages outside the context the connection was created, for instance in workers or third-party iframes.</p>
       <div>
       <p>The WebIDL changes are the following:
       <pre class="idl">
@@ -959,23 +958,22 @@ dictionary RTCEncodingOptions {
           the transceiver is sending enrypted RTP header extensions as defined in
           [[CRYPTEX]].
         </p>
-        <div>
-  <pre class="idl">
-  partial interface RTCRtpTransceiver {
-    readonly attribute boolean rtpHeaderEncryptionNegotiated;
-  };</pre>
+        <pre class="idl">
+partial interface RTCRtpTransceiver {
+  readonly attribute boolean rtpHeaderEncryptionNegotiated;
+};</pre>
       <section>
         <h2>
           Attributes
         </h2>
         <dl data-link-for="RTCRtpTransceiver" data-dfn-for=
         "RTCRtpTransceiver" class="attributes">
-        <dt>
-          <dfn id="dom-rtptransceiver-rtpHeaderEncryptionNegotiated">rtpHeaderEncryptionNegotiated</dfn> of type <span class=
+          <dt>
+            <dfn id="dom-rtptransceiver-rtpHeaderEncryptionNegotiated">rtpHeaderEncryptionNegotiated</dfn> of type <span class=
                   "idlAttrType">Boolean</span>, readonly, nullable
           </dt>
           <dd>
-          <p>
+            <p>
               The {{rtpHeaderEncryptionNegotiated}} attribute indicates whether [[CRYPTEX]] has been
               negotiated.  On getting, the attribute MUST
               return the value of the {{RTCRtpTransceiver/[[RtpHeaderEncryptionNegotiated]]}} slot.

--- a/index.html
+++ b/index.html
@@ -425,26 +425,26 @@ partial interface RTCRtpTransceiver {
                   <p>Update the underlying system about the new <var>target</var>,
                   or that there is no application preference if <var>target</var> is
                   <code>null</code>.</p>
-                </li>
-                <p>
-                  If <var>track</var> is synchronized with another
-                  {{RTCRtpReceiver}}'s track for
-                  <a data-cite="RFC5888#section-7">audio/video synchronization</a>,
-                  then the <a>user agent</a> SHOULD use the larger of the two receivers'
-                  {{RTCRtpReceiver/[[JitterBufferTarget]]}} for both receivers.
-                </p>
-                <p>
-                  When the underlying system is applying a jitter buffer target, it will
-                  continuously make sure that the actual jitter buffer target is clamped
-                  within the <a>minimum allowed target</a> and <a>maximum allowed
-                  target</a>.
-                  <p class="note">
-                    If the <a>user agent</a> ends up using a target different from the
-                    requested one (e.g. due to network conditions or physical memory
-                    constraints), this is not reflected in the
-                    {{RTCRtpReceiver/[[JitterBufferTarget]]}} internal slot.
+                  <p>
+                    If <var>track</var> is synchronized with another
+                    {{RTCRtpReceiver}}'s track for
+                    <a data-cite="RFC5888#section-7">audio/video synchronization</a>,
+                    then the <a>user agent</a> SHOULD use the larger of the two receivers'
+                    {{RTCRtpReceiver/[[JitterBufferTarget]]}} for both receivers.
                   </p>
-                </p>
+                  <p>
+                    When the underlying system is applying a jitter buffer target, it will
+                    continuously make sure that the actual jitter buffer target is clamped
+                    within the <a>minimum allowed target</a> and <a>maximum allowed
+                    target</a>.
+                    <p class="note">
+                      If the <a>user agent</a> ends up using a target different from the
+                      requested one (e.g. due to network conditions or physical memory
+                      constraints), this is not reflected in the
+                      {{RTCRtpReceiver/[[JitterBufferTarget]]}} internal slot.
+                    </p>
+                  </p>
+                </li>
                 <li>
                   <p>Modifying the jitter buffer target of the underlying system SHOULD
                   affect the internal audio or video buffering gradually in order not

--- a/index.html
+++ b/index.html
@@ -415,8 +415,6 @@ partial interface RTCRtpTransceiver {
               to <var>target</var>.</p>
             </li>
             <li>
-            </li>
-            <li>
               <p>Let <var>track</var> be <var>receiver</var>'s
               {{RTCRtpReceiver/[[ReceiverTrack]]}}.</p>
             </li>


### PR DESCRIPTION
Fixes a couple of respec issues that came up in #167


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-extensions/pull/173.html" title="Last updated on Jul 27, 2023, 3:00 PM UTC (793546b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/173/cbae391...fippo:793546b.html" title="Last updated on Jul 27, 2023, 3:00 PM UTC (793546b)">Diff</a>