### PR TITLE
Add RTCIceTransport method to remove candidate pairs

### DIFF
--- a/index.html
+++ b/index.html
@@ -855,7 +855,7 @@ dictionary RTCEncodingOptions {
           attribute EventHandler onicecandidatepairremove;
           attribute EventHandler onicecandidatepairnominate;
           undefined setSelectedCandidatePair(RTCIceCandidatePair candidatePair);
-          Promise&lt;undefined&gt; removeCandidatePairs(sequence&lt;RTCIceCandidatePair&gt; candidatePairs);
+          Promise&lt;undefined&gt; removeCandidatePair(RTCIceCandidatePair candidatePair);
         };</pre>
     <section id="rtcicetransport-attributes">
       <h2>Attributes</h2>
@@ -969,11 +969,11 @@ dictionary RTCEncodingOptions {
           </p>
         </dd>
         <dt>
-          <dfn>removeCandidatePairs</dfn>
+          <dfn>removeCandidatePair</dfn>
         </dt>
         <dd>
           <p>
-            The {{removeCandidatePairs}} method removes the provided candidate pairs. The [= ICE agent =] will stop sending and responding to ICE connectivity checks on the removed candidate pairs, and they can no longer be used to send data for this transport. This method is meant to be called when the application wants to free resources allocated for candidates that it no longer needs. The application cannot call {{RTCIceTransport/setSelectedCandidatePair}}() with a candidate pair removed with this method.
+            The {{removeCandidatePair}} method removes the provided candidate pair. The [= ICE agent =] will stop sending and responding to ICE connectivity checks on the removed candidate pair, and it can no longer be used to send data for this transport. This method is meant to be called when the application wants to free resources allocated for candidates that it no longer needs. The application cannot call {{RTCIceTransport/setSelectedCandidatePair}}() with a candidate pair removed with this method.
           </p>
           <p>
             When this method is invoked, the [= user agent =] MUST run the following steps:
@@ -1004,12 +1004,12 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                Let |candidatePairs:sequence&lt;RTCIceCandidatePair&gt;| be the method's first argument.
+                Let |candidatePair:RTCIceCandidatePair| be the method's first argument.
               </p>
             </li>
             <li>
               <p>
-                Let |filteredCandidatePairs:sequence&lt;RTCIceCandidatePair&gt;| be the result of filtering down <var>candidatePairs</var> to just the {{RTCIceCandidatePair}} elements whose  {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} attributes respectively match a pairing of {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} sent in {{RTCIceTransport/onicecandidatepairadd}}.
+                If the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} attributes of <var>candidatePair</var> do not match a pairing of {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} respectively sent in {{RTCIceTransport/onicecandidatepairadd}}, [= exception/throw =] a {{NotFoundError}}.
               </p>
             </li>
             <li>
@@ -1019,7 +1019,7 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                In parallel, instruct the [= ICE agent =] to remove the candidate pairs indicated by <var>filteredCandidatePairs</var>.
+                In parallel, instruct the [= ICE agent =] to remove the candidate pair indicated by <var>candidatePair</var>.
               </p>
               <ol>
                 <li>
@@ -1029,7 +1029,7 @@ dictionary RTCEncodingOptions {
                   <ol>
                     <li>
                       <p>
-                        For each |removedPair:RTCIceCandidatePair| in <var>filteredCandidatePairs</var> that was removed by the [= ICE agent =], [= fire an event =] named {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} candidates, respectively, of <var>removedPair</var>.
+                        [= Fire an event =] named {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} candidates, respectively, of <var>candidatePair</var>.
                       </p>
                     </li>
                     <li>

--- a/index.html
+++ b/index.html
@@ -1001,7 +1001,7 @@ dictionary RTCEncodingOptions {
         </dt>
         <dd>
           <p>
-            The {{removeCandidatePair}} method removes the provided candidate pair. The [= ICE agent =] will stop sending and responding to ICE connectivity checks on the removed candidate pair, and it can no longer be used to send data for this transport. This method is meant to be called when the application wants to free resources allocated for candidates that it no longer needs. The application cannot call {{RTCIceTransport/setSelectedCandidatePair}}() with a candidate pair removed with this method.
+            The {{removeCandidatePair}} method removes the provided candidate pair. The [= ICE agent =] will stop sending and responding to ICE connectivity checks on the removed candidate pair, and it can no longer be used to send data for this transport. This method is meant to be called when the application wants to free resources allocated for candidates that it no longer needs. The application cannot call {{RTCIceTransport/selectCandidatePair}}() with a candidate pair removed with this method.
           </p>
           <p>
             When this method is invoked, the [= user agent =] MUST run the following steps:

--- a/index.html
+++ b/index.html
@@ -985,8 +985,7 @@ dictionary RTCEncodingOptions {
         </dt>
         <dd>
           <p>
-            The {{removeCandidatePairs}} method removes the provided candidate pairs, making them unavailable to use
-            for transport. The [= ICE agent =] may free up candidates once all the associated candidate pairs have been removed.
+            The {{removeCandidatePairs}} method removes the provided candidate pairs. The [= ICE agent =] will stop sending and responding to ICE connectivity checks on the removed candidate pairs, and they can no longer be used to send data for this transport. This method is meant to be called when the application wants to free resources allocated for candidates that it no longer needs. The application cannot call {{RTCIceTransport/setSelectedCandidatePair}}() with a candidate pair removed with this method.
           </p>
           <p>
             When this method is invoked, the [= user agent =] MUST run the following steps:
@@ -994,7 +993,7 @@ dictionary RTCEncodingOptions {
           <ol class="algorithm">
             <li>
               <p>
-                Let |connection:RTCPeerConnection| be the {{RTCPeerConnection}} object associated with this [= ICE agent =].
+                Let |connection:RTCPeerConnection| be the {{RTCPeerConnection}} object associated with [= this =].
               </p>
             </li>
             <li>
@@ -1006,21 +1005,23 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                Let |transport:RTCIceTransport| be the associated {{RTCIceTransport}} object.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |transport|.{{RTCIceTransport/[[IceTransportState]]}} is either of
-                {{RTCIceTransportState/"new"}}, {{RTCIceTransportState/"failed"}} or {{RTCIceTransportState/"closed"}}, [=
-                exception/throw =]
-                an {{InvalidStateError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |transport|.{{RTCIceTransport/[[ProposalPending]]}} is <code>true</code>, [= exception/throw =] an
+                If [= this =].{{RTCIceTransport/[[ProposalPending]]}} is <code>true</code>, [= exception/throw =] an
                 {{InvalidStateError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                If [= this =].{{RTCIceTransport/[[IceTransportState]]}} is either of {{RTCIceTransportState/"new"}}, {{RTCIceTransportState/"failed"}} or {{RTCIceTransportState/"closed"}}, [= exception/throw =] an {{InvalidStateError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let |candidatePairs:sequence&lt;RTCIceCandidatePair&gt;| be the method's first argument.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let |filteredCandidatePairs:sequence&lt;RTCIceCandidatePair&gt;| be the result of filtering down <var>candidatePairs</var> to just the {{RTCIceCandidatePair}} elements whose  {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} attributes respectively match a pairing of {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} sent in {{RTCIceTransport/onicecandidatepairadd}}.
               </p>
             </li>
             <li>
@@ -1030,7 +1031,7 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                In parallel, instruct the [= ICE agent =] to remove the candidate pairs indicated by |candidatePairs|, ignoring any unknown or invalid candidate pairs.
+                In parallel, instruct the [= ICE agent =] to remove the candidate pairs indicated by <var>filteredCandidatePairs</var>.
               </p>
               <ol>
                 <li>
@@ -1040,8 +1041,7 @@ dictionary RTCEncodingOptions {
                   <ol>
                     <li>
                       <p>
-                        For each valid |removedPair| in |candidatePairs| that was removed by the [= ICE agent =], [= fire an event =] named {{RTCIceTransport/icecandidatepairremove}}
-                        at |transport|, using {{RTCIceCandidatePairEvent}}, with the {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of |removedPair|.
+                        For each |removedPair:RTCIceCandidatePair| in <var>filteredCandidatePairs</var> that was removed by the [= ICE agent =], [= fire an event =] named {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} candidates, respectively, of <var>removedPair</var>.
                       </p>
                     </li>
                     <li>

--- a/index.html
+++ b/index.html
@@ -82,6 +82,9 @@
       The process of <dfn data-lt="nominate|nominated|nomination">nominating</dfn> a candidate pair is defined in
       [[RFC8445]] Section 8.1.1.
     </p>
+    <p>
+      The process of <dfn data-lt="free|freed|freeing">freeing</dfn> a candidate is defined in [[RFC8445]] Section 8.3.
+    </p>
   </section>
   <section id="ice-csp">
     <h3>
@@ -818,7 +821,8 @@ dictionary RTCEncodingOptions {
       The [= ICE agent =] will continue to send data using |candidatePair| until instructed to use another candidate pair with {{RTCIceTransport/selectCandidatePair}}.
     </p>
     <p>
-      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn data-lt="candidate pair removed" id="rtcicetransport-remove">remove a candidate pair</dfn>:
+      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn
+        id="rtcicetransport-remove">remove a candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -844,7 +848,8 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |cancelable:boolean| be <code>true</code> if the candidate pair is being removed in order to free an unused candidate, and
+          Let |cancelable:boolean| be <code>true</code> if the candidate pair is being removed in order to [= free =] an unused
+          candidate, and
           <code>false</code> otherwise.
         </p>
       </li>
@@ -1027,7 +1032,11 @@ dictionary RTCEncodingOptions {
         </dt>
         <dd>
           <p>
-            The {{removeCandidatePair}} method removes the provided candidate pair. The [= ICE agent =] will stop sending and responding to ICE connectivity checks on the removed candidate pair, and it can no longer be used to send data for this transport. This method is meant to be called when the application wants to free resources allocated for candidates that it no longer needs. The application cannot call {{RTCIceTransport/selectCandidatePair}}() with a candidate pair removed with this method.
+            The {{removeCandidatePair}} method removes the provided candidate pair. The [= ICE agent =] will stop sending and
+            responding to ICE connectivity checks on the removed candidate pair, and it can no longer be used to send data for this
+            transport. This method is meant to be called when the application wants to allow the [= ICE agent =] to [= free =]
+            candidates that it no longer needs. The application cannot call {{RTCIceTransport/selectCandidatePair}}() with a
+            candidate pair removed with this method.
           </p>
           <p>
             When this method is invoked, the [= user agent =] MUST run the following steps:

--- a/index.html
+++ b/index.html
@@ -916,6 +916,7 @@ dictionary RTCEncodingOptions {
           attribute EventHandler onicecandidatepairremove;
           attribute EventHandler onicecandidatepairnominate;
           undefined setSelectedCandidatePair(RTCIceCandidatePair candidatePair);
+          undefined removeCandidatePairs(sequence&lt;RTCIceCandidatePair&gt; candidatePairs);
         };</pre>
     <section id="rtcicetransport-attributes">
       <h2>Attributes</h2>
@@ -974,6 +975,67 @@ dictionary RTCEncodingOptions {
             on the provided candidate pair. When this method is invoked, the [= user agent =] MUST run the steps to [= change the
             selected candidate pair =].
           </p>
+        </dd>
+        <dt>
+          <dfn>removeCandidatePairs</dfn>
+        </dt>
+        <dd>
+          <p>
+            The {{removeCandidatePairs}} method immediately removes the provided candidate pairs, making them unavailable to use
+            for transport. The [= ICE agent =] may free up candidates once all the associated candidate pairs have been removed.
+          </p>
+          <p>
+            When this method is invoked, the [= user agent =] MUST run the following steps:
+          </p>
+          <ol class="algorithm">
+            <li>
+              <p>
+                Let |connection:RTCPeerConnection| be the {{RTCPeerConnection}} object associated with this [= ICE agent =].
+              </p>
+            </li>
+            <li>
+              <p>
+                If <var>connection</var>.{{RTCPeerConnection/[[IsClosed]]}} is
+                <code>true</code>, [= exception/throw =] an
+                {{InvalidStateError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let |transport:RTCIceTransport| be the associated {{RTCIceTransport}} object.
+              </p>
+            </li>
+            <li>
+              <p>
+                If |transport|.{{RTCIceTransport/[[IceTransportState]]}} is either of
+                {{RTCIceTransportState/"new"}}, {{RTCIceTransportState/"failed"}} or {{RTCIceTransportState/"closed"}}, [=
+                exception/throw =]
+                an {{InvalidStateError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                If |transport|.{{RTCIceTransport/[[ProposalPending]]}} is <code>true</code>, [= exception/throw =] an
+                {{InvalidStateError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                Instruct the [= ICE agent =] to remove the candidate pairs indicated by |candidatePairs|, ignoring any unknown
+                or invalid candidate pairs.
+              </p>
+            </li>
+            <li>
+              <p>
+                For each valid |removedPair| in |candidatePairs| that was removed by the [= ICE agent =], [= fire an event =] named
+                {{RTCIceTransport/icecandidatepairremove}}
+                at |transport|, using {{RTCIceCandidatePairEvent}}, with the
+                {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}}
+                and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively,
+                of |removedPair|.
+              </p>
+            </li>
+          </ol>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -1035,8 +1035,7 @@ dictionary RTCEncodingOptions {
             The {{removeCandidatePair}} method removes the provided candidate pair. The [= ICE agent =] will stop sending and
             responding to ICE connectivity checks on the removed candidate pair, and it can no longer be used to send data for this
             transport. This method is meant to be called when the application wants to allow the [= ICE agent =] to [= free =]
-            candidates that it no longer needs. The application cannot call {{RTCIceTransport/selectCandidatePair}}() with a
-            candidate pair removed with this method.
+            candidates that it no longer needs.
           </p>
           <p>
             When this method is invoked, the [= user agent =] MUST run the following steps:

--- a/index.html
+++ b/index.html
@@ -827,6 +827,11 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
+          If |candidatePair| describes a [= candidate pair removed =] by the [= ICE agent =] or removed by the application by calling {{RTCIceTransport/removeCandidatePairs}}, [= exception/throw =] a {{NotFoundError}}.
+        </p>
+      </li>
+      <li>
+        <p>
           Instruct the [= ICE agent =] to use |candidatePair| to send data, and continue to the steps for a change in the selected
           candidate pair (leading up to {{RTCIceTransport/onselectedcandidatepairchange}}).
         </p>
@@ -839,8 +844,7 @@ dictionary RTCEncodingOptions {
       candidate pair.
     </p>
     <p>
-      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn
-        id="rtcicetransport-remove">remove a candidate pair</dfn>:
+      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn data-lt="candidate pair removed" id="rtcicetransport-remove">remove a candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -916,7 +920,7 @@ dictionary RTCEncodingOptions {
           attribute EventHandler onicecandidatepairremove;
           attribute EventHandler onicecandidatepairnominate;
           undefined setSelectedCandidatePair(RTCIceCandidatePair candidatePair);
-          undefined removeCandidatePairs(sequence&lt;RTCIceCandidatePair&gt; candidatePairs);
+          Promise&lt;undefined&gt; removeCandidatePairs(sequence&lt;RTCIceCandidatePair&gt; candidatePairs);
         };</pre>
     <section id="rtcicetransport-attributes">
       <h2>Attributes</h2>
@@ -981,7 +985,7 @@ dictionary RTCEncodingOptions {
         </dt>
         <dd>
           <p>
-            The {{removeCandidatePairs}} method immediately removes the provided candidate pairs, making them unavailable to use
+            The {{removeCandidatePairs}} method removes the provided candidate pairs, making them unavailable to use
             for transport. The [= ICE agent =] may free up candidates once all the associated candidate pairs have been removed.
           </p>
           <p>
@@ -1021,18 +1025,37 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                Instruct the [= ICE agent =] to remove the candidate pairs indicated by |candidatePairs|, ignoring any unknown
-                or invalid candidate pairs.
+                Let |p:Promise| be a new promise.
               </p>
             </li>
             <li>
               <p>
-                For each valid |removedPair| in |candidatePairs| that was removed by the [= ICE agent =], [= fire an event =] named
-                {{RTCIceTransport/icecandidatepairremove}}
-                at |transport|, using {{RTCIceCandidatePairEvent}}, with the
-                {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}}
-                and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively,
-                of |removedPair|.
+                In parallel, instruct the [= ICE agent =] to remove the candidate pairs indicated by |candidatePairs|, ignoring any unknown or invalid candidate pairs.
+              </p>
+              <ol>
+                <li>
+                  <p>
+                    When the [= ICE agent =] has completed the removal, [= queue a task =] to run the following steps:
+                  </p>
+                  <ol>
+                    <li>
+                      <p>
+                        For each valid |removedPair| in |candidatePairs| that was removed by the [= ICE agent =], [= fire an event =] named {{RTCIceTransport/icecandidatepairremove}}
+                        at |transport|, using {{RTCIceCandidatePairEvent}}, with the {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of |removedPair|.
+                      </p>
+                    </li>
+                    <li>
+                      <p>
+                        Resolve <var>p</var>.
+                      </p>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p>
+                Return <var>p</var>.
               </p>
             </li>
           </ol>


### PR DESCRIPTION
Fixes w3c/webrtc-extensions#170.

This PR extends the `RTCIceTransport` interface by adding a new method to allow an application to remove candidate pairs that are no longer needed for the peer connection. The new method `removeCandidatePairs` immediately removes the supplied candidate pairs, which are then sent in non-cancelable `icecandidatepairremove` events.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/175.html" title="Last updated on Jan 12, 2024, 10:42 AM UTC (d0d0ae1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/175/48e2a4a...sam-vi:d0d0ae1.html" title="Last updated on Jan 12, 2024, 10:42 AM UTC (d0d0ae1)">Diff</a>