### PR TITLE
Rename setSelectedCandidatePair and return a promise

### DIFF
--- a/index.html
+++ b/index.html
@@ -769,7 +769,7 @@ dictionary RTCEncodingOptions {
           If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not {{nominate}} |candidatePair|, and instead to
           continue to perform connectivity checks. The [= ICE agent =] may continue to send data using the candidate pair
           indicated by |candidatePair| unless instructed to use another candidate pair with
-          {{RTCIceTransport/setSelectedCandidatePair}}.
+          {{RTCIceTransport/selectCandidatePair}}.
         </p>
       </li>
       <li>
@@ -855,7 +855,7 @@ dictionary RTCEncodingOptions {
           attribute EventHandler onicecandidatepairadd;
           attribute EventHandler onicecandidatepairremove;
           attribute EventHandler onicecandidatepairnominate;
-          undefined setSelectedCandidatePair(RTCIceCandidatePair candidatePair);
+          undefined selectCandidatePair(RTCIceCandidatePair candidatePair);
         };</pre>
     <section id="rtcicetransport-attributes">
       <h2>Attributes</h2>
@@ -906,11 +906,11 @@ dictionary RTCEncodingOptions {
       <h2>Methods</h2>
       <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="methods">
         <dt>
-          <dfn>setSelectedCandidatePair</dfn>
+          <dfn>selectCandidatePair</dfn>
         </dt>
         <dd>
           <p>
-            The {{setSelectedCandidatePair}} method attempts to select a different candidate pair to send data
+            The {{selectCandidatePair}} method attempts to select a different candidate pair to send data
             over. If successful, data will be sent on the provided candidate pair.
             It is meant to be called after the application defers the {{nomination}} of a candidate pair
             by cancelling the {{RTCIceTransport/icecandidatepairnominate}} event.

--- a/index.html
+++ b/index.html
@@ -855,7 +855,7 @@ dictionary RTCEncodingOptions {
           attribute EventHandler onicecandidatepairadd;
           attribute EventHandler onicecandidatepairremove;
           attribute EventHandler onicecandidatepairnominate;
-          undefined selectCandidatePair(RTCIceCandidatePair candidatePair);
+          Promise&lt;undefined&gt; selectCandidatePair(RTCIceCandidatePair candidatePair);
         };</pre>
     <section id="rtcicetransport-attributes">
       <h2>Attributes</h2>
@@ -956,8 +956,36 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                Instruct the [= ICE agent =] to use |candidatePair| to send data, and continue to the steps for a change in the selected
-                candidate pair (leading up to {{RTCIceTransport/onselectedcandidatepairchange}}).
+                Let |p:Promise| be a new promise.
+              </p>
+            </li>
+            <li>
+              <p>
+                In parallel, instruct the [= ICE agent =] to use |candidatePair| to send data.
+              </p>
+              <ol>
+                <li>
+                  <p>
+                    When the [= ICE agent =] has completed selecting |candidatePair|, [= queue a task =] to run the following steps:
+                  </p>
+                  <ol>
+                    <li>
+                      <p>
+                        Run the steps for a change in the selected candidate pair for an {{RTCIceTransport}}, leading up to a change in the {{RTCIceTransport/[[SelectedCandidatePair]]}} internal slot and {{RTCIceTransport/onselectedcandidatepairchange}}.
+                      </p>
+                    </li>
+                    <li>
+                      <p>
+                        Resolve <var>p</var>.
+                      </p>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p>
+                Return <var>p</var>.
               </p>
             </li>
           </ol>


### PR DESCRIPTION
Fixes #178.
Fixes #182.

`setSelectedCandidatePair` is renamed to `selectCandidatePair` to indicate that the method is taking some action rather than immediately updating internal state.

The returned promise resolves when all changes performed by the method have been applied and relevant events have  fired.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/183.html" title="Last updated on Nov 13, 2023, 1:37 PM UTC (6173949)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/183/9e061e7...sam-vi:6173949.html" title="Last updated on Nov 13, 2023, 1:37 PM UTC (6173949)">Diff</a>