### PR TITLE
Refer to change of selected pair/state algo

### DIFF
--- a/index.html
+++ b/index.html
@@ -971,7 +971,7 @@ dictionary RTCEncodingOptions {
                   <ol>
                     <li>
                       <p>
-                        Run the steps for a change in the selected candidate pair for an {{RTCIceTransport}}, leading up to a change in the {{RTCIceTransport/[[SelectedCandidatePair]]}} internal slot and {{RTCIceTransport/onselectedcandidatepairchange}}.
+                        Run the steps labeled [=RTCIceTransport/change the selected candidate pair and state=] to update [=this=].{{RTCIceTransport/[[SelectedCandidatePair]]}} and [=this=].{{RTCIceTransport/[[IceTransportState]]}} as necessary and fire any associated events.
                       </p>
                     </li>
                     <li>


### PR DESCRIPTION
Fixes: #185.

Explicitly refer to the [change of selected candidate pair and state algo](https://w3c.github.io/webrtc-pc/#dfn-change-the-selected-candidate-pair-and-state) for RTCIceTransport in [selectCandidatePair](https://w3c.github.io/webrtc-extensions/#dom-rtcicetransport-selectcandidatepair) method.