### PR TITLE
Define an RTCIceCandidate match algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,21 +1113,36 @@ dictionary RTCEncodingOptions {
       <li>
         <p>
           If either (but not both) of |first|.{{RTCIceCandidate/sdpMid}} and |second|.{{RTCIceCandidate/sdpMid}} is
-          <code>null</code>, or neither of them is <code>null</code> and |first|.{{RTCIceCandidate/sdpMid}} is not [= string/identical to =]
+          <code>null</code>, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If neither of |first|.{{RTCIceCandidate/sdpMid}} and |second|.{{RTCIceCandidate/sdpMid}} is <code>null</code>, and |first|.{{RTCIceCandidate/sdpMid}} is not [= string/identical to =]
           |second|.{{RTCIceCandidate/sdpMid}}, return <code>false</code>.
         </p>
       </li>
       <li>
         <p>
           If either (but not both) of |first|.{{RTCIceCandidate/sdpMLineIndex}} and |second|.{{RTCIceCandidate/sdpMLineIndex}} is
-          <code>null</code>, or neither of them is <code>null</code> and |first|.{{RTCIceCandidate/sdpMLineIndex}} is not equal to
+          <code>null</code>, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If neither of |first|.{{RTCIceCandidate/sdpMLineIndex}} and |second|.{{RTCIceCandidate/sdpMLineIndex}} is <code>null</code> and |first|.{{RTCIceCandidate/sdpMLineIndex}} is not equal to
           |second|.{{RTCIceCandidate/sdpMLineIndex}}, return <code>false</code>.
         </p>
       </li>
       <li>
         <p>
           If either (but not both) of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is
-          <code>null</code>, or neither of them is <code>null</code> and |first|.{{RTCIceCandidate/usernameFragment}} is not [= string/identical to =]
+          <code>null</code>, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If neither of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is <code>null</code> and |first|.{{RTCIceCandidate/usernameFragment}} is not [= string/identical to =]
           |second|.{{RTCIceCandidate/usernameFragment}}, return <code>false</code>.
         </p>
       </li>

--- a/index.html
+++ b/index.html
@@ -1100,6 +1100,43 @@ dictionary RTCEncodingOptions {
         </section>
       </div>
     </section>
+    <p>
+      The <dfn>candidate match</dfn> algorithm given two {{RTCIceCandidate}} |first:RTCIceCandidate| and
+      |second:RTCIceCandidate| is as follows:
+    </p>
+    <ol class="algorithm">
+      <li>
+        <p>
+          If |first|.{{RTCIceCandidate/candidate}} is not [= string/identical to =] |second|.{{RTCIceCandidate/candidate}}, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If either (but not both) of |first|.{{RTCIceCandidate/sdpMid}} and |second|.{{RTCIceCandidate/sdpMid}} is
+          <code>null</code>, or neither of them is <code>null</code> and |first|.{{RTCIceCandidate/sdpMid}} is not [= string/identical to =]
+          |second|.{{RTCIceCandidate/sdpMid}}, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If either (but not both) of |first|.{{RTCIceCandidate/sdpMLineIndex}} and |second|.{{RTCIceCandidate/sdpMLineIndex}} is
+          <code>null</code>, or neither of them is <code>null</code> and |first|.{{RTCIceCandidate/sdpMLineIndex}} is not equal to
+          |second|.{{RTCIceCandidate/sdpMLineIndex}}, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If either (but not both) of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is
+          <code>null</code>, or neither of them is <code>null</code> and |first|.{{RTCIceCandidate/usernameFragment}} is not [= string/identical to =]
+          |second|.{{RTCIceCandidate/usernameFragment}}, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          Return <code>true</code>.
+        </p>
+      </li>
+    </ol>
   </section>
   <section id="rtcrtpcontributingsource-extensions">
     <h3>


### PR DESCRIPTION
Fixes: #186.

The algorithm matches the (non-derived) candidate, sdpMid, sdpMLineIndex, and usernameFragment attributes of RTCIceCandidate.

The candidate match algorithm will be used in the candidate pair match algorithm (#187), which will, in turn, be used in validation steps for RTCIceTransport methods (#188).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/192.html" title="Last updated on Jan 10, 2024, 9:49 AM UTC (ba8548b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/192/92bea5a...sam-vi:ba8548b.html" title="Last updated on Jan 10, 2024, 9:49 AM UTC (ba8548b)">Diff</a>