### PR TITLE
Define a candidate pair match algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1100,6 +1100,26 @@ dictionary RTCEncodingOptions {
         </section>
       </div>
     </section>
+    <p>
+      The <dfn>candidate pair match</dfn> algorithm given two {{RTCIceCandidatePair}} |first:RTCIceCandidatePair| and |second:RTCIceCandidatePair| is as follows:
+    </p>
+    <ol class="algorithm">
+      <li>
+        <p>
+          If |first|.{{RTCIceCandidatePair/local}} does not [= candidate match | match =] |second|.{{RTCIceCandidatePair/local}}, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          If |first|.{{RTCIceCandidatePair/remote}} does not [= candidate match | match =] |second|.{{RTCIceCandidatePair/remote}}, return <code>false</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          Return <code>true</code>.
+        </p>
+      </li>
+    </ol>
   </section>
   <section id="rtcrtpcontributingsource-extensions">
     <h3>


### PR DESCRIPTION
Fixes: #187.

This PR depends on the candidate match algorithm described in #192.

The candidate pair match algorithm will be used in validation steps for RTCIceTransport methods (#188).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/193.html" title="Last updated on Jan 12, 2024, 10:00 AM UTC (155805c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/193/48e2a4a...sam-vi:155805c.html" title="Last updated on Jan 12, 2024, 10:00 AM UTC (155805c)">Diff</a>