### PR TITLE
Add an internal slot for active candidate pairs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,12 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} attributes of <var>candidatePair</var> do not match a pairing of {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} respectively sent in {{RTCIceTransport/onicecandidatepairadd}}, [= exception/throw =] a {{NotFoundError}}.
+                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].{{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                [= list/Remove =] all items that [= candidate pair match | match =] |candidatePair| from [=this=].{{RTCIceTransport/[[CandidatePairs]]}}.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -897,7 +897,7 @@ dictionary RTCEncodingOptions {
         <ol>
           <li>
             <p>
-              [= list/Remove =] all items that [= candidate pair match | match =] |candidatePair| from |transport|.{{RTCIceTransport/[[CandidatePairs]]}}.
+              [= list/Remove =] |candidatePair| from |transport|.{{RTCIceTransport/[[CandidatePairs]]}}.
             </p>
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -1097,7 +1097,8 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].{{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
+                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].
+                {{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1007,7 +1007,8 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].{{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
+                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].
+                {{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -749,6 +749,11 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
+          [= list/Append =] |candidatePair| to {{RTCIceTransport/[[CandidatePairs]]}}.
+        </p>
+      </li>
+      <li>
+        <p>
           [= Fire an event =] named
           {{RTCIceTransport/icecandidatepairadd}} at |transport|, using {{RTCIceCandidatePairEvent}},
           with the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes
@@ -877,14 +882,29 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Otherwise, instruct the [= ICE agent =] to remove the candidate pair indicated by |candidatePair|.
+          Otherwise (if |accepted| is <code>true</code>), run the following steps:
         </p>
+        <ol>
+          <li>
+            <p>
+              [= list/Remove =] all items that [= candidate pair match | match =] |candidatePair| from |transport|.{{RTCIceTransport/[[CandidatePairs]]}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Instruct the [= ICE agent =] to remove the candidate pair indicated by |candidatePair|.
+            </p>
+          </li>
+        </ol>
       </li>
     </ol>
     <p>
-      The {{RTCIceTransport}} object is extended by adding the following internal slot:
+      The {{RTCIceTransport}} object is extended by adding the following internal slots:
     </p>
     <ul>
+      <li>
+        <dfn data-dfn-for="RTCIceTransport">[[\CandidatePairs]]</dfn> initialized to an empty list.
+      </li>
       <li>
         <dfn data-dfn-for="RTCIceTransport">[[\ProposalPending]]</dfn> initialized to <code>false</code>.
       </li>
@@ -976,8 +996,7 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If |candidatePair| does not describe a candidate pair formed for [=this=] {{RTCIceTransport}} and sent in
-                {{RTCIceTransport/onicecandidatepairadd}}, [= exception/throw =] a {{NotFoundError}}.
+                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].{{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1103,7 +1103,9 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                [= list/Remove =] all items that [= candidate pair match | match =] |candidatePair| from [=this=].{{RTCIceTransport/[[CandidatePairs]]}}.
+                [= list/Remove =] the item in
+                [=this=].{{RTCIceTransport/[[CandidatePairs]]}} that
+                [= candidate pair match | matches =] |candidatePair|.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -752,6 +752,12 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
+          [=Assert=]: |candidatePair| does not [= candidate pair match | match =] any
+          item in |transport|.{{RTCIceTransport/[[CandidatePairs]]}}
+        </p>
+      </li>
+      <li>
+        <p>
           [= list/Append =] |candidatePair| to {{RTCIceTransport/[[CandidatePairs]]}}.
         </p>
       </li>


### PR DESCRIPTION
Fixes: #188.

The [[CandidatePairs]] slot in RTCIceTransport tracks candidate pairs formed by the ICE agent and surfaced to the application, and not removed via icecandidatepairremove or removeCandidatePair().

The slot is used to validate the inputs to selectCandidatePair() and removeCandidatePair().

**EDIT:** To help Sameer make progress while OOO, I've re-uploaded this as #197 with comments addressed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/194.html" title="Last updated on Jan 25, 2024, 12:54 PM UTC (0c3c86c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/194/4c29534...sam-vi:0c3c86c.html" title="Last updated on Jan 25, 2024, 12:54 PM UTC (0c3c86c)">Diff</a>