### PR TITLE
Add an internal slot for active candidate pairs (re-upload)

### DIFF
--- a/index.html
+++ b/index.html
@@ -742,12 +742,26 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |candidatePair:RTCIceCandidatePair| be the candidate pair that was [= formed =].
+          Let |candidatePair:RTCIceCandidatePair| be a new {{RTCIceCandidatePair}} dictionary
+          with its {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} members
+          initialized to new {{RTCIceCandidate}}s representing the local and remote part of the
+          [= formed =] pair respectively.
         </p>
       </li>
       <li>
         <p>
           Let |transport:RTCIceTransport| be the {{RTCIceTransport}} object associated with |candidatePair|.
+        </p>
+      </li>
+      <li>
+        <p>
+          [=Assert=]: |candidatePair| does not [= candidate pair match | match =] any
+          item in |transport|.{{RTCIceTransport/[[CandidatePairs]]}}
+        </p>
+      </li>
+      <li>
+        <p>
+          [= list/Append =] |candidatePair| to {{RTCIceTransport/[[CandidatePairs]]}}.
         </p>
       </li>
       <li>
@@ -881,14 +895,29 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Otherwise, instruct the [= ICE agent =] to remove the candidate pair indicated by |candidatePair|.
+          Otherwise (if |accepted| is <code>true</code>), run the following steps:
         </p>
+        <ol>
+          <li>
+            <p>
+              [= list/Remove =] |candidatePair| from |transport|.{{RTCIceTransport/[[CandidatePairs]]}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Instruct the [= ICE agent =] to remove the candidate pair indicated by |candidatePair|.
+            </p>
+          </li>
+        </ol>
       </li>
     </ol>
     <p>
-      The {{RTCIceTransport}} object is extended by adding the following internal slot:
+      The {{RTCIceTransport}} object is extended by adding the following internal slots:
     </p>
     <ul>
+      <li>
+        <dfn data-dfn-for="RTCIceTransport">[[\CandidatePairs]]</dfn> initialized to an empty list.
+      </li>
       <li>
         <dfn data-dfn-for="RTCIceTransport">[[\ProposalPending]]</dfn> initialized to <code>false</code>.
       </li>
@@ -981,8 +1010,8 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If |candidatePair| does not describe a candidate pair formed for [=this=] {{RTCIceTransport}} and sent in
-                {{RTCIceTransport/onicecandidatepairadd}}, [= exception/throw =] a {{NotFoundError}}.
+                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].
+                {{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
               </p>
             </li>
             <li>
@@ -1071,7 +1100,15 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} attributes of <var>candidatePair</var> do not match a pairing of {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} respectively sent in {{RTCIceTransport/onicecandidatepairadd}}, [= exception/throw =] a {{NotFoundError}}.
+                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].
+                {{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                [= list/Remove =] the item in
+                [=this=].{{RTCIceTransport/[[CandidatePairs]]}} that
+                [= candidate pair match | matches =] |candidatePair|.
               </p>
             </li>
             <li>


### PR DESCRIPTION
Fixes: https://github.com/w3c/webrtc-extensions/issues/188.

Helping Sameer make progress while he is OOO. Original PR description:

> The [[CandidatePairs]] slot in RTCIceTransport tracks candidate pairs formed by the ICE agent and surfaced to the application, and not removed via icecandidatepairremove or removeCandidatePair().
>
> The slot is used to validate the inputs to selectCandidatePair() and removeCandidatePair().

This is a re-upload of #194 with all of @jan-ivar's comments addressed (including the one which was outside the diff), with the exception for the question "Also, do we need to clear [[CandidatePairs]] at some point during ICE restart?"

For this last comment I filed #196 since I wasn't sure whether or not this was covered by the existing removal steps (no opinion, just unblocking this first part)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-extensions/pull/197.html" title="Last updated on Jan 25, 2024, 12:54 PM UTC (d0c039b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/197/4c29534...henbos:d0c039b.html" title="Last updated on Jan 25, 2024, 12:54 PM UTC (d0c039b)">Diff</a>