### PR TITLE
Clarify when `icecandidatepairremove` is fired.

### DIFF
--- a/index.html
+++ b/index.html
@@ -679,7 +679,21 @@ dictionary RTCEncodingOptions {
       The [= ICE agent =] will continue to send data using |candidatePair| until instructed to use another candidate pair with {{RTCIceTransport/selectCandidatePair}}.
     </p>
     <p>
-      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn
+      The [= ICE agent =] can decide to remove a candidate pair for several reasons. Examples include:
+    </p>
+    <ul>
+      <li>
+        A candidate could be [= freed =] because it is not associated with the selected candidate pair.
+      </li>
+      <li>
+        A candidate pair is no longer available due to a loss of the associated network interface.
+      </li>
+      <li>
+        All candidate pairs are being removed due to an ICE restart, as described in section 9 of [[RFC8445]].
+      </li>
+    </ul>
+    <p>
+      When the [= ICE agent =] has decided to remove a candidate pair, the [= user agent =] MUST [= queue a task =] to <dfn
         id="rtcicetransport-remove">remove a candidate pair</dfn>:
     </p>
     <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -457,7 +457,6 @@ partial interface RTCRtpTransceiver {
           restrictions are orientation agnostic, see note below. When scaling is
           applied, both dimensions of the frame MUST be downscaled using the
           same factor.</p>
-        </dd>
         <p class="note">
           The restrictions being orientation agnostic means that they will
           automatically be adjusted to the orientation of the frame being
@@ -466,6 +465,7 @@ partial interface RTCRtpTransceiver {
           720x1280 is specified, both always result in the exact same scaling
           factor regardless of the orientation of the frame.
         </p>
+        </dd>
       </dl>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -678,20 +678,20 @@ dictionary RTCEncodingOptions {
     <p class="note">
       The [= ICE agent =] will continue to send data using |candidatePair| until instructed to use another candidate pair with {{RTCIceTransport/selectCandidatePair}}.
     </p>
-    <p>
+    <div class="note">
       The [= ICE agent =] can decide to remove a candidate pair for several reasons. Examples include:
-    </p>
-    <ul>
-      <li>
-        A candidate could be [= freed =] because it is not associated with the selected candidate pair.
-      </li>
-      <li>
-        A candidate pair is no longer available due to a loss of the associated network interface.
-      </li>
-      <li>
-        All candidate pairs are being removed due to an ICE restart, as described in section 9 of [[RFC8445]].
-      </li>
-    </ul>
+      <ul>
+        <li>
+          A candidate could be [= freed =] because it is not associated with the selected candidate pair.
+        </li>
+        <li>
+          A candidate pair is no longer available due to a loss of the associated network interface.
+        </li>
+        <li>
+          All candidate pairs are being removed due to an ICE restart, as described in section 9 of [[RFC8445]].
+        </li>
+      </ul>
+    </div>
     <p>
       When the [= ICE agent =] has decided to remove a candidate pair, the [= user agent =] MUST [= queue a task =] to <dfn
         id="rtcicetransport-remove">remove a candidate pair</dfn>:


### PR DESCRIPTION
Fixes: #196.

Enumerate examples of situations in which `icecandidatepairremove` is fired, including ICE restart.

This makes it clear that the event is fired and `[[CandidatePairs]]` is cleared in the event of an ICE restart.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/204.html" title="Last updated on May 14, 2025, 3:21 PM UTC (33c359d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/204/6a77bc0...sam-vi:33c359d.html" title="Last updated on May 14, 2025, 3:21 PM UTC (33c359d)">Diff</a>