### PR TITLE
Use RTCIceCandidatePair interface in RTCIceTransport

### DIFF
--- a/index.html
+++ b/index.html
@@ -586,10 +586,9 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |candidatePair:RTCIceCandidatePair| be a new {{RTCIceCandidatePair}} dictionary
-          with its {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} members
-          initialized to new {{RTCIceCandidate}}s representing the local and remote part of the
-          [= formed =] pair respectively.
+          Let |candidatePair:RTCIceCandidatePair| be the result of [= creating an RTCIceCandidatePair =] with
+          |local:RTCIceCandidate| and |remote:RTCIceCandidate|, representing the local and remote candidates of the [= formed =]
+          pair respectively.
         </p>
       </li>
       <li>
@@ -612,8 +611,8 @@ dictionary RTCEncodingOptions {
         <p>
           [= Fire an event =] named
           {{RTCIceTransport/icecandidatepairadd}} at |transport|, using {{RTCIceCandidatePairEvent}},
-          with the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes
-          initialized to the local and remote candidates, respectively, of |candidatePair|.
+          with the {{RTCIceCandidatePairEvent/candidatePair}} attribute
+          initialized to |candidatePair|.
         </p>
       </li>
     </ol>
@@ -654,9 +653,8 @@ dictionary RTCEncodingOptions {
         <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/icecandidatepairnominate}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
-          {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/local}} and
-          {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of
-          |candidatePair|.
+          {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/candidatePair}} attribute
+          initialized to |candidatePair|.
         </p>
       </li>
       <li>
@@ -720,9 +718,8 @@ dictionary RTCEncodingOptions {
         <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
-          {{Event/cancelable}} attribute initialized to <var>cancelable</var>, and the {{RTCIceCandidatePairEvent/local}}
-          and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively,
-          of |candidatePair|.
+          {{Event/cancelable}} attribute initialized to <var>cancelable</var>, and the {{RTCIceCandidatePairEvent/candidatePair}} attribute
+          initialized to |candidatePair|.
         </p>
       </li>
       <li>
@@ -972,7 +969,7 @@ dictionary RTCEncodingOptions {
                   <ol>
                     <li>
                       <p>
-                        [= Fire an event =] named {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} candidates, respectively, of <var>candidatePair</var>.
+                        [= Fire an event =] named {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the {{Event/cancelable}} attribute initialized to <code>false</code>, and the {{RTCIceCandidatePairEvent/candidatePair}} attribute initialized to |candidatePair|.
                       </p>
                     </li>
                     <li>
@@ -998,15 +995,15 @@ dictionary RTCEncodingOptions {
         <dfn>RTCIceCandidatePairEvent</dfn>
       </h2>
       <p>
-        The {{RTCIceTransport/icecandidatepairadd}} and {{RTCIceTransport/icecandidatepairremove}} events use the
+        The {{RTCIceTransport/icecandidatepairadd}}, {{RTCIceTransport/icecandidatepairnominate}} and
+        {{RTCIceTransport/icecandidatepairremove}} events use the
         {{RTCIceCandidatePairEvent}} interface.
       </p>
       <div>
         <pre class="idl">[Exposed=Window]
   interface RTCIceCandidatePairEvent : Event {
     constructor(DOMString type, RTCIceCandidatePairEventInit eventInitDict);
-    readonly attribute RTCIceCandidate local;
-    readonly attribute RTCIceCandidate remote;
+    readonly attribute RTCIceCandidatePair candidatePair;
   };</pre>
         <section id="rtcicecandidatepairevent-constructors">
           <h4>Constructors</h4>
@@ -1019,21 +1016,11 @@ dictionary RTCEncodingOptions {
           <h4>Attributes</h4>
           <dl data-link-for="RTCIceCandidatePairEvent" data-dfn-for="RTCIceCandidatePairEvent" class="attributes">
             <dt>
-              <dfn>local</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, readonly
+              <dfn>candidatePair</dfn> of type <span class="idlAttrType">{{RTCIceCandidatePair}}</span>, readonly
             </dt>
             <dd>
               <p>
-                The {{local}} attribute represents the local {{RTCIceCandidate}} of the candidate pair associated with the
-                event.
-              </p>
-            </dd>
-            <dt>
-              <dfn>remote</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The {{remote}} attribute represents the remote {{RTCIceCandidate}} of the candidate pair associated with
-                the event.
+                The {{candidatePair}} attribute represents the candidate pair associated with the event.
               </p>
             </dd>
           </dl>
@@ -1042,27 +1029,18 @@ dictionary RTCEncodingOptions {
       <div>
         <pre class="idl">
   dictionary RTCIceCandidatePairEventInit : EventInit {
-    required RTCIceCandidate local;
-    required RTCIceCandidate remote;
+    required RTCIceCandidatePair candidatePair;
   };</pre>
         <section id="rtcicecandidatepaireventinit">
           <h4>Dictionary <dfn>RTCIceCandidatePairEventInit</dfn> Members</h4>
           <dl data-link-for="RTCIceCandidatePairEventInit" data-dfn-for="RTCIceCandidatePairEventInit"
             class="dictionary-members">
             <dt>
-              <dfn>local</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, required
+              <dfn>candidatePair</dfn> of type <span class="idlAttrType">{{RTCIceCandidatePair}}</span>, required
             </dt>
             <dd>
               <p>
-                The local {{RTCIceCandidate}} of the candidate pair announced by the event.
-              </p>
-            </dd>
-            <dt>
-              <dfn>remote</dfn> of type <span class="idlAttrType">{{RTCIceCandidate}}</span>, required
-            </dt>
-            <dd>
-              <p>
-                The remote {{RTCIceCandidate}} of the candidate pair announced by the event.
+                The candidate pair announced by the event.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -598,8 +598,7 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          [=Assert=]: |candidatePair| does not [= candidate pair match | match =] any
-          item in |transport|.{{RTCIceTransport/[[CandidatePairs]]}}
+          [=Assert=]: |transport|.{{RTCIceTransport/[[CandidatePairs]]}} does not [= list/contain =] |candidatePair|.
         </p>
       </li>
       <li>
@@ -851,8 +850,7 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].
-                {{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
+                If [=this=].{{RTCIceTransport/[[CandidatePairs]]}} does not [= list/contain =] |candidatePair|, [= exception/throw =] a {{NotFoundError}}.
               </p>
             </li>
             <li>
@@ -941,15 +939,13 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].
-                {{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
+                If [=this=].{{RTCIceTransport/[[CandidatePairs]]}} does not [= list/contain =] |candidatePair|, [= exception/throw =] a {{NotFoundError}}.
               </p>
             </li>
             <li>
               <p>
-                [= list/Remove =] the item in
-                [=this=].{{RTCIceTransport/[[CandidatePairs]]}} that
-                [= candidate pair match | matches =] |candidatePair|.
+                [= list/Remove =] |candidatePair| from
+                [=this=].{{RTCIceTransport/[[CandidatePairs]]}}.
               </p>
             </li>
             <li>
@@ -1048,7 +1044,7 @@ dictionary RTCEncodingOptions {
       </div>
     </section>
     <p>
-      The <dfn>candidate match</dfn> algorithm given two {{RTCIceCandidate}} |first:RTCIceCandidate| and
+      The <dfn class="export">candidate match</dfn> algorithm given two {{RTCIceCandidate}} |first:RTCIceCandidate| and
       |second:RTCIceCandidate| is as follows:
     </p>
     <ol class="algorithm">
@@ -1091,26 +1087,6 @@ dictionary RTCEncodingOptions {
         <p>
           If neither of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is <code>null</code> and |first|.{{RTCIceCandidate/usernameFragment}} is not [= string/identical to =]
           |second|.{{RTCIceCandidate/usernameFragment}}, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          Return <code>true</code>.
-        </p>
-      </li>
-    </ol>
-    <p>
-      The <dfn>candidate pair match</dfn> algorithm given two {{RTCIceCandidatePair}} |first:RTCIceCandidatePair| and |second:RTCIceCandidatePair| is as follows:
-    </p>
-    <ol class="algorithm">
-      <li>
-        <p>
-          If |first|.{{RTCIceCandidatePair/local}} does not [= candidate match | match =] |second|.{{RTCIceCandidatePair/local}}, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          If |first|.{{RTCIceCandidatePair/remote}} does not [= candidate match | match =] |second|.{{RTCIceCandidatePair/remote}}, return <code>false</code>.
         </p>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -457,7 +457,6 @@ partial interface RTCRtpTransceiver {
           restrictions are orientation agnostic, see note below. When scaling is
           applied, both dimensions of the frame MUST be downscaled using the
           same factor.</p>
-        </dd>
         <p class="note">
           The restrictions being orientation agnostic means that they will
           automatically be adjusted to the orientation of the frame being
@@ -466,6 +465,7 @@ partial interface RTCRtpTransceiver {
           720x1280 is specified, both always result in the exact same scaling
           factor regardless of the orientation of the frame.
         </p>
+        </dd>
       </dl>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -1043,58 +1043,69 @@ dictionary RTCEncodingOptions {
         </section>
       </div>
     </section>
-    <p>
-      The <dfn class="export">candidate match</dfn> algorithm given two {{RTCIceCandidate}} |first:RTCIceCandidate| and
-      |second:RTCIceCandidate| is as follows:
-    </p>
-    <ol class="algorithm">
-      <li>
-        <p>
-          If |first|.{{RTCIceCandidate/candidate}} is not [= string/identical to =] |second|.{{RTCIceCandidate/candidate}}, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          If either (but not both) of |first|.{{RTCIceCandidate/sdpMid}} and |second|.{{RTCIceCandidate/sdpMid}} is
-          <code>null</code>, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          If neither of |first|.{{RTCIceCandidate/sdpMid}} and |second|.{{RTCIceCandidate/sdpMid}} is <code>null</code>, and |first|.{{RTCIceCandidate/sdpMid}} is not [= string/identical to =]
-          |second|.{{RTCIceCandidate/sdpMid}}, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          If either (but not both) of |first|.{{RTCIceCandidate/sdpMLineIndex}} and |second|.{{RTCIceCandidate/sdpMLineIndex}} is
-          <code>null</code>, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          If neither of |first|.{{RTCIceCandidate/sdpMLineIndex}} and |second|.{{RTCIceCandidate/sdpMLineIndex}} is <code>null</code> and |first|.{{RTCIceCandidate/sdpMLineIndex}} is not equal to
-          |second|.{{RTCIceCandidate/sdpMLineIndex}}, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          If either (but not both) of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is
-          <code>null</code>, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          If neither of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is <code>null</code> and |first|.{{RTCIceCandidate/usernameFragment}} is not [= string/identical to =]
-          |second|.{{RTCIceCandidate/usernameFragment}}, return <code>false</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          Return <code>true</code>.
-        </p>
-      </li>
-    </ol>
+    <section id="rtcicetransport-change-pair-state-modifications">
+      <h2>Modifications to existing procedures</h2>
+      <p>
+        In the steps to [=RTCIceTransport/change the selected candidate pair and state=], if the selected candidate pair was changed, modify the first step to the following:
+      </p>
+      <ol class="algorithm">
+        <li>
+          Let <var>newCandidatePair</var> be the [= list/item =] [= list/contained =] in |this|.{{RTCIceTransport/[[CandidatePairs]]}} whose {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} attributes respectively [= candidate match | match =] the local and remote candidates of the indicated pair if one is selected, and <code>null</code> otherwise.
+        </li>
+      </ol>
+      <p>
+        The <dfn class="export">candidate match</dfn> algorithm given two {{RTCIceCandidate}} |first:RTCIceCandidate| and
+        |second:RTCIceCandidate| is as follows:
+      </p>
+      <ol class="algorithm">
+        <li>
+          <p>
+            If |first|.{{RTCIceCandidate/candidate}} is not [= string/identical to =] |second|.{{RTCIceCandidate/candidate}}, return <code>false</code>.
+          </p>
+        </li>
+        <li>
+          <p>
+            If either (but not both) of |first|.{{RTCIceCandidate/sdpMid}} and |second|.{{RTCIceCandidate/sdpMid}} is
+            <code>null</code>, return <code>false</code>.
+          </p>
+        </li>
+        <li>
+          <p>
+            If neither of |first|.{{RTCIceCandidate/sdpMid}} and |second|.{{RTCIceCandidate/sdpMid}} is <code>null</code>, and |first|.{{RTCIceCandidate/sdpMid}} is not [= string/identical to =]
+            |second|.{{RTCIceCandidate/sdpMid}}, return <code>false</code>.
+          </p>
+        </li>
+        <li>
+          <p>
+            If either (but not both) of |first|.{{RTCIceCandidate/sdpMLineIndex}} and |second|.{{RTCIceCandidate/sdpMLineIndex}} is
+            <code>null</code>, return <code>false</code>.
+          </p>
+        </li>
+        <li>
+          <p>
+            If neither of |first|.{{RTCIceCandidate/sdpMLineIndex}} and |second|.{{RTCIceCandidate/sdpMLineIndex}} is <code>null</code> and |first|.{{RTCIceCandidate/sdpMLineIndex}} is not equal to
+            |second|.{{RTCIceCandidate/sdpMLineIndex}}, return <code>false</code>.
+          </p>
+        </li>
+        <li>
+          <p>
+            If either (but not both) of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is
+            <code>null</code>, return <code>false</code>.
+          </p>
+        </li>
+        <li>
+          <p>
+            If neither of |first|.{{RTCIceCandidate/usernameFragment}} and |second|.{{RTCIceCandidate/usernameFragment}} is <code>null</code> and |first|.{{RTCIceCandidate/usernameFragment}} is not [= string/identical to =]
+            |second|.{{RTCIceCandidate/usernameFragment}}, return <code>false</code>.
+          </p>
+        </li>
+        <li>
+          <p>
+            Return <code>true</code>.
+          </p>
+        </li>
+      </ol>
+    </section>
   </section>
   <section id="rtcrtpcontributingsource-extensions">
     <h3>

--- a/index.html
+++ b/index.html
@@ -616,7 +616,7 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          [= list/Append =] |candidatePair| to {{RTCIceTransport/[[CandidatePairs]]}}.
+          [= list/Append =] |candidatePair| to |transport|.{{RTCIceTransport/[[CandidatePairs]]}}.
         </p>
       </li>
       <li>


### PR DESCRIPTION
Addresses: w3c/webrtc-pc#2930.

This change is built on top of w3c/webrtc-pc#2961, which converts RTCIceCandidatePair from a dictionary to an interface.

- Change RTCIceCandidatePairEvent to contain a single RTCIceCandidatePair attribute.
- Modify RTCIceTransport algo so that getSelectedCandidatePair() returns an item from [[CandidatePairs]].
- Validate RTCIceCandidatePair inputs using object identity instead of candidate pair match algo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/205.html" title="Last updated on May 14, 2025, 3:22 PM UTC (ca19e02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/205/6a77bc0...sam-vi:ca19e02.html" title="Last updated on May 14, 2025, 3:22 PM UTC (ca19e02)">Diff</a>