### PR TITLE
Fix links by s/codec match/codec dictionary match/

### DIFF
--- a/index.html
+++ b/index.html
@@ -429,7 +429,7 @@ partial interface RTCRtpTransceiver {
         </li>
         <li>
           <p>If any <var>encoding</var> in encodings [=map/exists|contains=] a codec
-            [= codec match | not found =] in <var>choosableCodecs</var>, return a promise
+            [= codec dictionary match | not found =] in <var>choosableCodecs</var>, return a promise
             [= rejected =] with a newly [= exception/created =] {{InvalidModificationError}}.</p>
         </li>
         <li>
@@ -443,7 +443,7 @@ partial interface RTCRtpTransceiver {
       <p>Add the following steps to the [=RTCPeerConnection/addTransceiver sendEncodings validation steps=]:</p>
       <ol>
         <li>
-          <p>If any <var>codec</var> parameter in <var>sendEncodings</var> does [= codec match | not match =] any codec in
+          <p>If any <var>codec</var> parameter in <var>sendEncodings</var> does [= codec dictionary match | not match =] any codec in
           {{RTCRtpSender.getCapabilities(kind)}}.<code>codecs</code>,
           [= exception/throw =] an {{OperationError}}.</p>
         </li>
@@ -467,7 +467,7 @@ partial interface RTCRtpTransceiver {
               <ol>
                 <li>
                   <p>Remove any <var>codec</var> value in <var>transceiver</var>.{{RTCRtpTransceiver/[[Sender]]}}.{{RTCRtpSender/[[SendEncodings]]}}
-                    that does not [= codec match | match =] any entry in <var>codecs</var>.</p>
+                    that does not [= codec dictionary match | match =] any entry in <var>codecs</var>.</p>
                 </li>
               </ol>
             </li>


### PR DESCRIPTION
Fix links to match merging of https://github.com/w3c/webrtc-pc/pull/2958.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/206.html" title="Last updated on Apr 18, 2024, 4:04 PM UTC (b65516f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/206/7c31919...b65516f.html" title="Last updated on Apr 18, 2024, 4:04 PM UTC (b65516f)">Diff</a>