### PR TITLE
Add scaleResolutionDownTo to RTCRtpEncodingParameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,8 +375,8 @@ partial interface RTCRtpTransceiver {
           applied when this parameter is used. Instead, frames are either sent
           as-is or they are downscaled by the encoder to uphold the
           restrictions. The encoder will never upscale a frame. In simulcast,
-          this can result in dropping top layer(s) if the input frame is too
-          small as to avoid sending the same resolution on multiple layers.</p>
+          encodings are sent up to and including the layer that results in a
+          downscale, ignoring any layers further up.</p>
           <p>When setting parameters, if {{resolutionRestriction}} is specified
           on any encoding, check that the following is true or else throw an
           {{InvalidModificationError}}:</p>

--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@ partial interface RTCRtpTransceiver {
         <dd>
           <p>The maximum height that frames will be encoded with.
           The restrictions are orientation agnostic, see note below.
-          When scaling is applied, both dimensions of the frame are downscaled
+          When scaling is applied, both dimensions of the frame MUST be downscaled
           using the same factor.</p>
         </dd>
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@ partial interface RTCRtpTransceiver {
         <dd>
           <p>The maximum dimensions at which to restrict this encoding.</p>
           <p>When {{scaleResolutionDownTo}} is specified, the
-          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} scaling factor MUST
+          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} value MUST
           be ignored by the encoder. Instead, frames are sent according to the
           specified resolution restrictions: frames MUST either be downscaled or
           sent as-is. The encoder MUST NOT upscale a frame. In simulcast, not

--- a/index.html
+++ b/index.html
@@ -459,8 +459,8 @@ partial interface RTCRtpTransceiver {
           <dfn data-idl>maxHeight</dfn> of type <span class="idlMemberType">unsigned long</span>
         </dt>
         <dd>
-          <p>The maximum height that frames will be encoded with without getting
-          downscaled. The restrictions are orientation agnostic, see note below.
+          <p>The maximum height that frames will be encoded with.
+          The restrictions are orientation agnostic, see note below.
           When scaling is applied, both dimensions of the frame are downscaled
           using the same factor.</p>
         </dd>

--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@ partial interface RTCRtpTransceiver {
       additional members to control audio packetization.
     </p>
     <pre class="idl">partial dictionary RTCRtpEncodingParameters {
-    RTCResolutionRestriction restrictedResolution;
+    RTCResolutionRestriction resolutionRestriction;
     unsigned long            ptime;
     boolean                  adaptivePtime = false;
 };</pre>
@@ -367,7 +367,7 @@ partial interface RTCRtpTransceiver {
       <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
       <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for="RTCRtpEncodingParameters" class="dictionary-members">
         <dt>
-          <dfn data-idl>restrictedResolution</dfn> of type <span class="idlMemberType">{{RTCResolutionRestriction}}</span>
+          <dfn data-idl>resolutionRestriction</dfn> of type <span class="idlMemberType">{{RTCResolutionRestriction}}</span>
         </dt>
         <dd>
           <p>The resolution at which to restrict this encoding.</p>
@@ -377,12 +377,12 @@ partial interface RTCRtpTransceiver {
           restrictions. The encoder will never upscale a frame. In simulcast,
           this can result in dropping top layer(s) if the input frame is too
           small as to avoid sending the same resolution on multiple layers.</p>
-          <p>When setting parameters, if {{restrictedResolution}} is specified
+          <p>When setting parameters, if {{resolutionRestriction}} is specified
           on any encoding, check that the following is true or else throw an
           {{InvalidModificationError}}:</p>
           <ul>
             <li>
-              <p>{{restrictedResolution}} is specified on all encodings and has
+              <p>{{resolutionRestriction}} is specified on all encodings and has
               values in both dimensions that are greater than 0.</p>
             </li>
             <li>
@@ -464,7 +464,7 @@ partial interface RTCRtpTransceiver {
         in landscape mode but the frame is in portrait mode or vice versa, the
         encoder will internally swap the restricted width and height prior to
         each size comparison. This does not modify the value of
-        {{RTCRtpEncodingParameters/restrictedResolution}}.
+        {{RTCRtpEncodingParameters/resolutionRestriction}}.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -372,15 +372,9 @@ partial interface RTCRtpTransceiver {
         <dd>
           <p>The maximum dimensions at which to restrict this encoding.</p>
           <p>When {{scaleResolutionDownTo}} is specified, the
-          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} value MUST
-          be ignored. Instead, frames are sent according to the
-          specified resolution restrictions: frames MUST NOT be upscaled. In simulcast, not
-          upscaling can result in multiple same-sized encodings if the size of
-          the frame is smaller than {{scaleResolutionDownTo}}; an encoding MUST
-          NOT be sent if {{scaleResolutionDownTo}} is larger than the frame and
-          there exists another {{RTCRtpEncodingParameters/active}} encoding with
-          a smaller {{scaleResolutionDownTo}} density resulting in the same
-          size.</p>
+          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} value MUST be
+          ignored. Instead, frames are sent according to the specified
+          resolution restrictions: frames MUST NOT be upscaled.</p>
           <p>When configuring parameters, the following validation MUST be
           performed if {{scaleResolutionDownTo}} is specified on any encoding or
           else {{RTCPeerConnection/addTransceiver()}} [= exception/throws =] a
@@ -450,19 +444,19 @@ partial interface RTCRtpTransceiver {
           <dfn data-idl>maxWidth</dfn> of type <span class="idlMemberType">unsigned long</span>
         </dt>
         <dd>
-          <p>The maximum width that frames will be encoded with.
-          The restrictions are orientation agnostic, see note below.
-          When scaling is applied, both dimensions of the frame are downscaled
-          using the same factor.</p>
+          <p>The maximum width that frames will be encoded with. The
+          restrictions are orientation agnostic, see note below. When scaling is
+          applied, both dimensions of the frame are downscaled using the same
+          factor.</p>
         </dd>
         <dt>
           <dfn data-idl>maxHeight</dfn> of type <span class="idlMemberType">unsigned long</span>
         </dt>
         <dd>
-          <p>The maximum height that frames will be encoded with.
-          The restrictions are orientation agnostic, see note below.
-          When scaling is applied, both dimensions of the frame MUST be downscaled
-          using the same factor.</p>
+          <p>The maximum height that frames will be encoded with. The
+          restrictions are orientation agnostic, see note below. When scaling is
+          applied, both dimensions of the frame MUST be downscaled using the
+          same factor.</p>
         </dd>
         <p class="note">
           The restrictions being orientation agnostic means that they will

--- a/index.html
+++ b/index.html
@@ -449,17 +449,26 @@ partial interface RTCRtpTransceiver {
         </dt>
         <dd>
           <p>The maximum width that frames will be encoded with without getting
-          downscaled. When scaling is applied, both dimensions of the frame are
-          downscaled using the same factor.</p>
+          downscaled. The restrictions are orientation agnostic, see note below.
+          When scaling is applied, both dimensions of the frame are downscaled
+          using the same factor.</p>
         </dd>
         <dt>
           <dfn data-idl>maxHeight</dfn> of type <span class="idlMemberType">unsigned long</span>
         </dt>
         <dd>
           <p>The maximum height that frames will be encoded with without getting
-          downscaled. When scaling is applied, both dimensions of the frame are
-          downscaled using the same factor.</p>
+          downscaled. The restrictions are orientation agnostic, see note below.
+          When scaling is applied, both dimensions of the frame are downscaled
+          using the same factor.</p>
         </dd>
+        <p class="note">
+          The restrictions being orientation agnostic means that they will
+          automatically be adjusted to portrait mode or landscape mode depending
+          on the orientation of the frame being restricted. This means that it
+          does not matter if 1280x720 or 720x1280 is specified, both always
+          result in the exact same scaling factor.
+        </p>
       </dl>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -374,8 +374,7 @@ partial interface RTCRtpTransceiver {
           <p>When {{scaleResolutionDownTo}} is specified, the
           {{RTCRtpEncodingParameters/scaleResolutionDownBy}} value MUST
           be ignored. Instead, frames are sent according to the
-          specified resolution restrictions: frames MUST either be downscaled or
-          sent as-is. The encoder MUST NOT upscale a frame. In simulcast, not
+          specified resolution restrictions: frames MUST NOT be upscaled. In simulcast, not
           upscaling can result in multiple same-sized encodings if the size of
           the frame is smaller than {{scaleResolutionDownTo}}; an encoding MUST
           NOT be sent if {{scaleResolutionDownTo}} is larger than the frame and

--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@ partial interface RTCRtpTransceiver {
           <p>The maximum dimensions at which to restrict this encoding.</p>
           <p>When {{scaleResolutionDownTo}} is specified, the
           {{RTCRtpEncodingParameters/scaleResolutionDownBy}} value MUST
-          be ignored by the encoder. Instead, frames are sent according to the
+          be ignored. Instead, frames are sent according to the
           specified resolution restrictions: frames MUST either be downscaled or
           sent as-is. The encoder MUST NOT upscale a frame. In simulcast, not
           upscaling can result in multiple same-sized encodings if the size of

--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@ partial interface RTCRtpTransceiver {
       additional members to control audio packetization.
     </p>
     <pre class="idl">partial dictionary RTCRtpEncodingParameters {
-    RTCResolutionRestriction resolutionRestriction;
+    RTCResolutionRestriction scaleResolutionDownTo;
     unsigned long            ptime;
     boolean                  adaptivePtime = false;
 };</pre>
@@ -367,22 +367,26 @@ partial interface RTCRtpTransceiver {
       <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
       <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for="RTCRtpEncodingParameters" class="dictionary-members">
         <dt>
-          <dfn data-idl>resolutionRestriction</dfn> of type <span class="idlMemberType">{{RTCResolutionRestriction}}</span>
+          <dfn data-idl>scaleResolutionDownTo</dfn> of type <span class="idlMemberType">{{RTCResolutionRestriction}}</span>
         </dt>
         <dd>
-          <p>The resolution at which to restrict this encoding.</p>
+          <p>The maximum dimensions at which to restrict this encoding.</p>
           <p>The default "scale resolution down by" factors (e.g. 4:2:1) are not
           applied when this parameter is used. Instead, frames are either sent
           as-is or they are downscaled by the encoder to uphold the
           restrictions. The encoder will never upscale a frame. In simulcast,
-          encodings are sent up to and including the layer that results in a
-          downscale, ignoring any layers further up.</p>
-          <p>When setting parameters, if {{resolutionRestriction}} is specified
+          not upscaling can result in multiple same-sized encodings if the size
+          of the frame is smaller than {{scaleResolutionDownTo}}; an encoding is
+          not sent if {{scaleResolutionDownTo}} is larger than the frame and
+          there exists another {{RTCRtpEncodingParameters/active}} encoding with
+          a smaller {{scaleResolutionDownTo}} density resulting in the same
+          size.</p>
+          <p>When setting parameters, if {{scaleResolutionDownTo}} is specified
           on any encoding, check that the following is true or else throw an
           {{InvalidModificationError}}:</p>
           <ul>
             <li>
-              <p>{{resolutionRestriction}} is specified on all encodings and has
+              <p>{{scaleResolutionDownTo}} is specified on all encodings and has
               values in both dimensions that are greater than 0.</p>
             </li>
             <li>
@@ -445,27 +449,18 @@ partial interface RTCRtpTransceiver {
         </dt>
         <dd>
           <p>The maximum width that frames will be encoded with without getting
-          downscaled. The size comparison is orientation agnostic. When scaling
-          is applied, both dimensions of the frame are downscaled using the same
-          factor.</p>
+          downscaled. When scaling is applied, both dimensions of the frame are
+          downscaled using the same factor.</p>
         </dd>
         <dt>
           <dfn data-idl>maxHeight</dfn> of type <span class="idlMemberType">unsigned long</span>
         </dt>
         <dd>
           <p>The maximum height that frames will be encoded with without getting
-          downscaled. The size comparison is orientation agnostic. When scaling
-          is applied, both dimensions of the frame are downscaled using the same
-          factor.</p>
+          downscaled. When scaling is applied, both dimensions of the frame are
+          downscaled using the same factor.</p>
         </dd>
       </dl>
-      <p class="note">
-        Orientation agnostic means that if resolution restrictions are specified
-        in landscape mode but the frame is in portrait mode or vice versa, the
-        encoder will internally swap the restricted width and height prior to
-        each size comparison. This does not modify the value of
-        {{RTCRtpEncodingParameters/resolutionRestriction}}.
-      </p>
     </section>
   </section>
   <section id="rtcrtpsender-setparameters-keyframe">

--- a/index.html
+++ b/index.html
@@ -359,12 +359,38 @@ partial interface RTCRtpTransceiver {
       additional members to control audio packetization.
     </p>
     <pre class="idl">partial dictionary RTCRtpEncodingParameters {
-  unsigned long ptime;
-  boolean adaptivePtime = false;
+    RTCResolutionRestriction restrictedResolution;
+    unsigned long            ptime;
+    boolean                  adaptivePtime = false;
 };</pre>
     <section id="rtcrtpencodingparameters-attributes">
       <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
       <dl data-link-for="RTCRtpEncodingParameters" data-dfn-for="RTCRtpEncodingParameters" class="dictionary-members">
+        <dt>
+          <dfn data-idl>restrictedResolution</dfn> of type <span class="idlMemberType">{{RTCResolutionRestriction}}</span>
+        </dt>
+        <dd>
+          <p>The resolution at which to restrict this encoding.</p>
+          <p>The default "scale resolution down by" factors (e.g. 4:2:1) are not
+          applied when this parameter is used. Instead, frames are either sent
+          as-is or they are downscaled by the encoder to uphold the
+          restrictions. The encoder will never upscale a frame. In simulcast,
+          this can result in dropping top layer(s) if the input frame is too
+          small as to avoid sending the same resolution on multiple layers.</p>
+          <p>When setting parameters, if {{restrictedResolution}} is specified
+          on any encoding, check that the following is true or else throw an
+          {{InvalidModificationError}}:</p>
+          <ul>
+            <li>
+              <p>{{restrictedResolution}} is specified on all encodings and has
+              values in both dimensions that are greater than 0.</p>
+            </li>
+            <li>
+              <p>{{RTCRtpEncodingParameters/scaleResolutionDownBy}} is not
+              specified on any encoding.</p>
+            </li>
+          </ul>
+        </dd>
         <dt>
           <dfn data-idl>ptime</dfn> of type <span class="idlMemberType">unsigned long</span>
         </dt>
@@ -401,6 +427,45 @@ partial interface RTCRtpTransceiver {
           based on the current network conditions.</p>
         </dd>
       </dl>
+    </section>
+  </section>
+  <section id="rtcresolutionrestriction">
+    <h3>
+      The {{RTCResolutionRestriction}} dictionary.
+    </h3>
+    <pre class="idl">dictionary RTCResolutionRestriction {
+    unsigned long maxWidth;
+    unsigned long maxHeight;
+};</pre>
+    <section id="rtcresolutionrestriction-attributes">
+      <h2>Dictionary {{RTCResolutionRestriction}} Members</h2>
+      <dl data-link-for="RTCResolutionRestriction" data-dfn-for="RTCResolutionRestriction" class="dictionary-members">
+        <dt>
+          <dfn data-idl>maxWidth</dfn> of type <span class="idlMemberType">unsigned long</span>
+        </dt>
+        <dd>
+          <p>The maximum width that frames will be encoded with without getting
+          downscaled. The size comparison is orientation agnostic. When scaling
+          is applied, both dimensions of the frame are downscaled using the same
+          factor.</p>
+        </dd>
+        <dt>
+          <dfn data-idl>maxHeight</dfn> of type <span class="idlMemberType">unsigned long</span>
+        </dt>
+        <dd>
+          <p>The maximum height that frames will be encoded with without getting
+          downscaled. The size comparison is orientation agnostic. When scaling
+          is applied, both dimensions of the frame are downscaled using the same
+          factor.</p>
+        </dd>
+      </dl>
+      <p class="note">
+        Orientation agnostic means that if resolution restrictions are specified
+        in landscape mode but the frame is in portrait mode or vice versa, the
+        encoder will internally swap the restricted width and height prior to
+        each size comparison. This does not modify the value of
+        {{RTCRtpEncodingParameters/restrictedResolution}}.
+      </p>
     </section>
   </section>
   <section id="rtcrtpsender-setparameters-keyframe">

--- a/index.html
+++ b/index.html
@@ -467,7 +467,8 @@ partial interface RTCRtpTransceiver {
           automatically be adjusted to portrait mode or landscape mode depending
           on the orientation of the frame being restricted. This means that it
           does not matter if 1280x720 or 720x1280 is specified, both always
-          result in the exact same scaling factor.
+          result in the exact same scaling factor regardless of the orientation
+          of the frame.
         </p>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -464,11 +464,11 @@ partial interface RTCRtpTransceiver {
         </dd>
         <p class="note">
           The restrictions being orientation agnostic means that they will
-          automatically be adjusted to portrait mode or landscape mode depending
-          on the orientation of the frame being restricted. This means that it
-          does not matter if 1280x720 or 720x1280 is specified, both always
-          result in the exact same scaling factor regardless of the orientation
-          of the frame.
+          automatically be adjusted to the orientation of the frame being
+          restricted (portrait mode or landscape mode) by swapping width and
+          height if necessary. This means that it does not matter if 1280x720 or
+          720x1280 is specified, both always result in the exact same scaling
+          factor regardless of the orientation of the frame.
         </p>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -382,11 +382,11 @@ partial interface RTCRtpTransceiver {
           there exists another {{RTCRtpEncodingParameters/active}} encoding with
           a smaller {{scaleResolutionDownTo}} density resulting in the same
           size.</p>
-          <p>When configuring parameters - either via
-          {{RTCPeerConnection/addTransceiver()}} or
-          {{RTCRtpSender/setParameters()}} - if {{scaleResolutionDownTo}} is
-          specified on any encoding, check that the following is true or else
-          [= exception/throw =] / [= reject =] with a newly
+          <p>When configuring parameters, the following validation MUST be
+          performed if {{scaleResolutionDownTo}} is specified on any encoding or
+          else {{RTCPeerConnection/addTransceiver()}} [= exception/throws =] a
+          newly [= exception/created =] {{OperationError}} and
+          {{RTCRtpSender/setParameters()}} [= reject|rejects =] with a newly
           [= exception/created =] {{InvalidModificationError}}:</p>
           <ul>
             <li>

--- a/index.html
+++ b/index.html
@@ -382,7 +382,8 @@ partial interface RTCRtpTransceiver {
           a smaller {{scaleResolutionDownTo}} density resulting in the same
           size.</p>
           <p>When setting parameters, if {{scaleResolutionDownTo}} is specified
-          on any encoding, check that the following is true or else throw an
+          on any encoding, check that the following is true or else return a
+          promise [= rejected =] with a newly [= exception/created =]
           {{InvalidModificationError}}:</p>
           <ul>
             <li>

--- a/index.html
+++ b/index.html
@@ -450,8 +450,8 @@ partial interface RTCRtpTransceiver {
           <dfn data-idl>maxWidth</dfn> of type <span class="idlMemberType">unsigned long</span>
         </dt>
         <dd>
-          <p>The maximum width that frames will be encoded with without getting
-          downscaled. The restrictions are orientation agnostic, see note below.
+          <p>The maximum width that frames will be encoded with.
+          The restrictions are orientation agnostic, see note below.
           When scaling is applied, both dimensions of the frame are downscaled
           using the same factor.</p>
         </dd>

--- a/index.html
+++ b/index.html
@@ -371,28 +371,30 @@ partial interface RTCRtpTransceiver {
         </dt>
         <dd>
           <p>The maximum dimensions at which to restrict this encoding.</p>
-          <p>The default "scale resolution down by" factors (e.g. 4:2:1) are not
-          applied when this parameter is used. Instead, frames are either sent
-          as-is or they are downscaled by the encoder to uphold the
-          restrictions. The encoder will never upscale a frame. In simulcast,
-          not upscaling can result in multiple same-sized encodings if the size
-          of the frame is smaller than {{scaleResolutionDownTo}}; an encoding is
-          not sent if {{scaleResolutionDownTo}} is larger than the frame and
+          <p>When {{scaleResolutionDownTo}} is specified, the
+          {{RTCRtpEncodingParameters/scaleResolutionDownBy}} scaling factor MUST
+          be ignored by the encoder. Instead, frames are sent according to the
+          specified resolution restrictions: frames MUST either be downscaled or
+          sent as-is. The encoder MUST NOT upscale a frame. In simulcast, not
+          upscaling can result in multiple same-sized encodings if the size of
+          the frame is smaller than {{scaleResolutionDownTo}}; an encoding MUST
+          NOT be sent if {{scaleResolutionDownTo}} is larger than the frame and
           there exists another {{RTCRtpEncodingParameters/active}} encoding with
           a smaller {{scaleResolutionDownTo}} density resulting in the same
           size.</p>
-          <p>When setting parameters, if {{scaleResolutionDownTo}} is specified
-          on any encoding, check that the following is true or else return a
-          promise [= rejected =] with a newly [= exception/created =]
-          {{InvalidModificationError}}:</p>
+          <p>When configuring parameters - either via
+          {{RTCPeerConnection/addTransceiver()}} or
+          {{RTCRtpSender/setParameters()}} - if {{scaleResolutionDownTo}} is
+          specified on any encoding, check that the following is true or else
+          [= exception/throw =] / [= reject =] with a newly
+          [= exception/created =] {{InvalidModificationError}}:</p>
           <ul>
             <li>
-              <p>{{scaleResolutionDownTo}} is specified on all encodings and has
-              values in both dimensions that are greater than 0.</p>
+              <p>{{scaleResolutionDownTo}} is specified on all encodings.</p>
             </li>
             <li>
-              <p>{{RTCRtpEncodingParameters/scaleResolutionDownBy}} is not
-              specified on any encoding.</p>
+              <p>For each {{scaleResolutionDownTo}} value, both dimensions have
+              a value greater than 0.</p>
             </li>
           </ul>
         </dd>


### PR DESCRIPTION
Fixes #159.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-extensions/pull/221.html" title="Last updated on Sep 12, 2024, 3:34 PM UTC (0ec01b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/221/5aaf7b2...henbos:0ec01b0.html" title="Last updated on Sep 12, 2024, 3:34 PM UTC (0ec01b0)">Diff</a>