### PR TITLE
nit: r/are/MUST be downscaled

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,8 +446,8 @@ partial interface RTCRtpTransceiver {
         <dd>
           <p>The maximum width that frames will be encoded with. The
           restrictions are orientation agnostic, see note below. When scaling is
-          applied, both dimensions of the frame are downscaled using the same
-          factor.</p>
+          applied, both dimensions of the frame MUST be downscaled using the
+          same factor.</p>
         </dd>
         <dt>
           <dfn data-idl>maxHeight</dfn> of type <span class="idlMemberType">unsigned long</span>


### PR DESCRIPTION
Fixing a nit from #221 that had editors can integrate on it: in the maxWidth description I had written "are downscaled" and in the maxHeight description I had written "MUST be downscaled", we should be consistent here, changing in preference of MUST. This relates to issue #159


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-extensions/pull/223.html" title="Last updated on Sep 16, 2024, 8:12 AM UTC (40b5c3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/223/20a6eb2...henbos:40b5c3e.html" title="Last updated on Sep 16, 2024, 8:12 AM UTC (40b5c3e)">Diff</a>