### PR TITLE
Don't require specifying scaleResolutionDownTo on inactive encodings

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,7 +383,8 @@ partial interface RTCRtpTransceiver {
           [= exception/created =] {{InvalidModificationError}}:</p>
           <ul>
             <li>
-              <p>{{scaleResolutionDownTo}} is specified on all encodings.</p>
+              <p>{{scaleResolutionDownTo}} is specified on all
+              {{RTCRtpEncodingParameters/active}} encodings.</p>
             </li>
             <li>
               <p>For each {{scaleResolutionDownTo}} value, both dimensions have


### PR DESCRIPTION
Fixes #227


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-extensions/pull/228.html" title="Last updated on Oct 23, 2024, 12:46 PM UTC (8d1f8be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/228/e9d88a9...henbos:8d1f8be.html" title="Last updated on Oct 23, 2024, 12:46 PM UTC (8d1f8be)">Diff</a>