### PR TITLE
Add capture/receive/RTP timestamps definitions for RTCRtpReceiver frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -1553,21 +1553,21 @@ partial interface RTCRtpTransceiver {
       </tbody>
     </table>
   </section>
-  <section class="informative">
+  <section>
     <h2>Timestamp behavior</h2>
-    <h2>RTCRtpSender timestamp effects on packet NTP and RTP timestamps</h2>
+    <h2>RTCRtpSender video track frame timestamp effects on outgoing packet NTP and RTP timestamps</h2>
     <p>
       The user agent defines a <dfn class="export">frame timestamp</dfn> being the same as the [=capture timestamp=]
       of the frame being produced on the {{RTCRtpSender}} {{MediaStreamTrack}} if it is set.
-      If it is unset the user agent estimates a timestamp from the sent frame's [=presentation timestamp=] together with the
+      If it is unset the user agent MUST estimate a timestamp from the sent frame's [=presentation timestamp=] together with the
       time it was received by the {{RTCRtpSender}}.
     </p>
     <p>
       The NTP and RTP timestamps of the encoded frame corresponding to the frame being produced on the {{RTCRtpSender}}
-      {{MediaStreamTrack}} are sourced from the [=frame timestamp=].
+      {{MediaStreamTrack}} MUST be sourced from the [=frame timestamp=].
     </p>
     <p>
-      The [=RTP timestamp=] of frames being produced on the {{RTCRtpSender}} is ignored.
+      The [=RTP timestamp=] of frames produced on the {{RTCRtpSender}} {{MediaStreamTrack}} SHOULD not be used by the {{RTCRtpSender}}.
     </p>
     <h2>RTCRtpReceiver timestamps</h2>
     <h3>Remote capture timestamp</h3>
@@ -1583,12 +1583,12 @@ partial interface RTCRtpTransceiver {
     </p>
     <h3>Received RTP timestamp</h3>
     <p>
-      For a frame produced in a {{RTCRtpReceiver}} track, the frame's [=RTP timestamp=] is set
+      For a video frame produced in a {{RTCRtpReceiver}} track, the frame's [=RTP timestamp=] MUST be set
       from the RTP timestamp of constituent packets of the corresponding received encoded frame.
     </p>
     <h3>Receive timestamp</h3>
     <p>
-      For a frame produced in a {{RTCRtpReceiver}} track, the [=receive timestamp=] is set
+      For a frame produced in a {{RTCRtpReceiver}} track, the [=receive timestamp=] MUST be set
       as the time the corresponding encoded frame was received by the platform, i.e. the time at which the
       last packet belonging to this frame was received over the network.
     </p>

--- a/index.html
+++ b/index.html
@@ -1560,14 +1560,11 @@ partial interface RTCRtpTransceiver {
       The user agent defines a <dfn class="export">frame timestamp</dfn> being the same as the [=capture timestamp=]
       of the frame being produced on the {{RTCRtpSender}} {{MediaStreamTrack}} if it is set.
       If it is unset the user agent MUST estimate a timestamp from the sent frame's [=presentation timestamp=] together with the
-      time it was received by the {{RTCRtpSender}}.
+      time it was received by the {{RTCRtpSender}}. This estimate MUST NOT be based on [= RTP timestamp =].
     </p>
     <p>
       The NTP and RTP timestamps of the encoded frame corresponding to the frame being produced on the {{RTCRtpSender}}
       {{MediaStreamTrack}} MUST be sourced from the [=frame timestamp=].
-    </p>
-    <p>
-      The [=RTP timestamp=] of frames produced on the {{RTCRtpSender}} {{MediaStreamTrack}} SHOULD not be used by the {{RTCRtpSender}}.
     </p>
     <h2>RTCRtpReceiver timestamps</h2>
     <h3>Remote capture timestamp</h3>

--- a/index.html
+++ b/index.html
@@ -72,6 +72,19 @@
     <p>
       The process of <dfn data-lt="free|freed|freeing">freeing</dfn> a candidate is defined in [[RFC8445]] Section 8.3.
     </p>
+
+    <p>
+      <!-- TODO: use the xref mechanism when mediacapture-extensions spec status is cleared up.
+           See https://github.com/w3c/mediacapture-extensions/issues/132 -->
+      The following terms are defined in <a href="https://w3c.github.io/mediacapture-extensions">mediacapture-extensions</a>
+      <a href="https://w3c.github.io/mediacapture-extensions/#video-timestamp-concepts/">video timestamp concepts</a>
+    </p>
+    <ul>
+      <li><dfn>presentation timestamp</dfn></li>
+      <li><dfn>capture timestamp</dfn></li>
+      <li><dfn>receive timestamp</dfn></li>
+      <li><dfn>RTP timestamp</dfn></li>
+    </ul>
   </section>
   <section id="ice-csp">
     <h3>
@@ -1539,6 +1552,46 @@ partial interface RTCRtpTransceiver {
         </tr>
       </tbody>
     </table>
+  </section>
+  <section class="informative">
+    <h2>Timestamp behavior</h2>
+    <h2>RTCRtpSender timestamp effects on packet NTP and RTP timestamps</h2>
+    <p>
+      The user agent defines a <dfn class="export">frame timestamp</dfn> being the same as the [=capture timestamp=]
+      of the frame being produced on the {{RTCRtpSender}} {{MediaStreamTrack}} if it is set.
+      If it is unset the user agent estimates a timestamp from the sent frame's [= presentation timestamp =] together with the
+      time it was received by the {{RTCRtpSender}}.
+    </p>
+    <p>
+      The NTP and RTP timestamps of the encoded frame corresponding to the frame being produced on the {{RTCRtpSender}}
+      {{MediaStreamTrack}} are sourced from the [= frame timestamp =].
+    </p>
+    <p>
+      The [=RTP timestamp=] of frames being produced on the {{RTCRtpSender}} is ignored.
+    </p>
+    <h2>RTCRtpReceiver timestamps</h2>
+    <h3>Remote capture timestamp</h3>
+    <p>
+      <!-- TODO: How this is estimated is under specified and should be fixed, but the section holds the requestVideoFrameCallback text for now -->
+      For a frame produced in a {{RTCRtpReceiver}} track, the user agent computes a
+      <dfn class="export">remote capture timestamp</dfn>. It is a best-effort estimate of the local capture
+      time on the sender translated to the receiver clock, and can use methods like using RTCP SR
+      as specified in [[?RFC3550]] Section 6.4.1, or by other alternative means if use by RTCP SR
+      isn't feasible.
+    </p><p>
+      Each frame's [= capture timestamp =] is set to the [= remote capture timestamp =], if available.
+    </p>
+    <h3>Received RTP timestamp</h3>
+    <p>
+      For a frame produced in a {{RTCRtpReceiver}} track, the frame's [=RTP timestamp=] is set
+      from the RTP timestamp of constituent packets of the corresponding received encoded frame.
+    </p>
+    <h3>Receive timestamp</h3>
+    <p>
+      For a frame produced in a {{RTCRtpReceiver}} track, the [=receive timestamp=] is set
+      as the time the corresponding encoded frame was received by the platform, i.e. the time at which the
+      last packet belonging to this frame was received over the network.
+    </p>
   </section>
   <section class="informative" id="security-considerations">
     <h2>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,6 @@
       <a href="https://w3c.github.io/mediacapture-extensions/#video-timestamp-concepts/">video timestamp concepts</a>
     </p>
     <ul>
-      <li><dfn>presentation timestamp</dfn></li>
       <li><dfn>capture timestamp</dfn></li>
       <li><dfn>receive timestamp</dfn></li>
       <li><dfn>RTP timestamp</dfn></li>
@@ -1558,7 +1557,7 @@ partial interface RTCRtpTransceiver {
     <h3>RTCRtpReceiver timestamps</h3>
     <h4>Remote capture timestamp</h4>
     <p>
-      For a frame produced in a {{RTCRtpReceiver}} track, the user agent may compute a
+      For a frame produced in a {{RTCRtpReceiver}} track, it is possible for the user agent to compute a
       <dfn class="export">remote capture timestamp</dfn>. It is a best-effort estimate of the capture
       time of the frame translated to the receiver clock, and can use methods like using RTCP SR
       as specified in [[?RFC3550]] Section 6.4.1, or by other alternative means if use by RTCP SR
@@ -1567,7 +1566,8 @@ partial interface RTCRtpTransceiver {
       [=RTP Header Extension for Absolute Capture Time=].
     </p>
     <p>
-      Each frame's [=capture timestamp=] MUST be set to the [=remote capture timestamp=], if available.
+      Each frame's [=capture timestamp=] MUST be set to the [=remote capture timestamp=], if the information
+      required to compute it is available.
     </p>
     <h4>Received RTP timestamp</h4>
     <p>

--- a/index.html
+++ b/index.html
@@ -1567,7 +1567,7 @@ partial interface RTCRtpTransceiver {
       [=RTP Header Extension for Absolute Capture Time=].
     </p>
     <p>
-      Each frame's [=capture timestamp=] is set to the [=remote capture timestamp=], if available.
+      Each frame's [=capture timestamp=] MUST be set to the [=remote capture timestamp=], if available.
     </p>
     <h4>Received RTP timestamp</h4>
     <p>

--- a/index.html
+++ b/index.html
@@ -1555,35 +1555,25 @@ partial interface RTCRtpTransceiver {
   </section>
   <section>
     <h2>Timestamp behavior</h2>
-    <h2>RTCRtpSender video track frame timestamp effects on outgoing packet NTP and RTP timestamps</h2>
+    <h3>RTCRtpReceiver timestamps</h3>
+    <h4>Remote capture timestamp</h4>
     <p>
-      The user agent defines a <dfn class="export">frame timestamp</dfn> being the same as the [=capture timestamp=]
-      of the frame being produced on the {{RTCRtpSender}} {{MediaStreamTrack}} if it is set.
-      If it is unset the user agent MUST estimate a timestamp from the sent frame's [=presentation timestamp=] together with the
-      time it was received by the {{RTCRtpSender}}. This estimate MUST NOT be based on [= RTP timestamp =].
-    </p>
-    <p>
-      The NTP and RTP timestamps of the encoded frame corresponding to the frame being produced on the {{RTCRtpSender}}
-      {{MediaStreamTrack}} MUST be sourced from the [=frame timestamp=].
-    </p>
-    <h2>RTCRtpReceiver timestamps</h2>
-    <h3>Remote capture timestamp</h3>
-    <p>
-      <!-- TODO: How this is estimated is under specified and should be fixed, but the section holds the requestVideoFrameCallback text for now -->
-      For a frame produced in a {{RTCRtpReceiver}} track, the user agent computes a
-      <dfn class="export">remote capture timestamp</dfn>. It is a best-effort estimate of the local capture
-      time on the sender translated to the receiver clock, and can use methods like using RTCP SR
+      For a frame produced in a {{RTCRtpReceiver}} track, the user agent may compute a
+      <dfn class="export">remote capture timestamp</dfn>. It is a best-effort estimate of the capture
+      time of the frame translated to the receiver clock, and can use methods like using RTCP SR
       as specified in [[?RFC3550]] Section 6.4.1, or by other alternative means if use by RTCP SR
       isn't feasible.
+      The capture time of an incoming frame is available if its constituent RTP packets contain the
+      [=RTP Header Extension for Absolute Capture Time=].
     </p><p>
       Each frame's [=capture timestamp=] is set to the [=remote capture timestamp=], if available.
     </p>
-    <h3>Received RTP timestamp</h3>
+    <h4>Received RTP timestamp</h4>
     <p>
       For a video frame produced in a {{RTCRtpReceiver}} track, the frame's [=RTP timestamp=] MUST be set
       from the RTP timestamp of constituent packets of the corresponding received encoded frame.
     </p>
-    <h3>Receive timestamp</h3>
+    <h4>Receive timestamp</h4>
     <p>
       For a frame produced in a {{RTCRtpReceiver}} track, the [=receive timestamp=] MUST be set
       as the time the corresponding encoded frame was received by the platform, i.e. the time at which the

--- a/index.html
+++ b/index.html
@@ -1559,12 +1559,12 @@ partial interface RTCRtpTransceiver {
     <p>
       The user agent defines a <dfn class="export">frame timestamp</dfn> being the same as the [=capture timestamp=]
       of the frame being produced on the {{RTCRtpSender}} {{MediaStreamTrack}} if it is set.
-      If it is unset the user agent estimates a timestamp from the sent frame's [= presentation timestamp =] together with the
+      If it is unset the user agent estimates a timestamp from the sent frame's [=presentation timestamp=] together with the
       time it was received by the {{RTCRtpSender}}.
     </p>
     <p>
       The NTP and RTP timestamps of the encoded frame corresponding to the frame being produced on the {{RTCRtpSender}}
-      {{MediaStreamTrack}} are sourced from the [= frame timestamp =].
+      {{MediaStreamTrack}} are sourced from the [=frame timestamp=].
     </p>
     <p>
       The [=RTP timestamp=] of frames being produced on the {{RTCRtpSender}} is ignored.
@@ -1579,7 +1579,7 @@ partial interface RTCRtpTransceiver {
       as specified in [[?RFC3550]] Section 6.4.1, or by other alternative means if use by RTCP SR
       isn't feasible.
     </p><p>
-      Each frame's [= capture timestamp =] is set to the [= remote capture timestamp =], if available.
+      Each frame's [=capture timestamp=] is set to the [=remote capture timestamp=], if available.
     </p>
     <h3>Received RTP timestamp</h3>
     <p>

--- a/index.html
+++ b/index.html
@@ -1565,7 +1565,8 @@ partial interface RTCRtpTransceiver {
       isn't feasible.
       The capture time of an incoming frame is available if its constituent RTP packets contain the
       [=RTP Header Extension for Absolute Capture Time=].
-    </p><p>
+    </p>
+    <p>
       Each frame's [=capture timestamp=] is set to the [=remote capture timestamp=], if available.
     </p>
     <h4>Received RTP timestamp</h4>

--- a/webrtc-extensions.js
+++ b/webrtc-extensions.js
@@ -1,50 +1,52 @@
 var respecConfig = {
-   "group": "webrtc",
-    github: {
-      repoURL: "https://github.com/w3c/webrtc-extensions/",
-      branch: "main"
-    },
+  "group": "webrtc",
+  github: {
+    repoURL: "https://github.com/w3c/webrtc-extensions/",
+    branch: "main"
+  },
   latestVersion: null,
-    "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "infra", "dom"],
-    "specStatus": "ED",
-    editors:  [
-      //              { name: "Your Name", url: "http://example.org/",
-      //                company: "Your Company", companyURL: "http://example.com/" },
-      { name: "Bernard Aboba", company: "Microsoft Corporation",
-        w3cid: "65611"
-      }
-    ],
-    formerEditors: [
-      { name: "Henrik Boström", company: "Google", w3cid: "96936", retiredDate: "2021-02-01" }
-    ],
-    authors: [
-    ],
-    wgPublicList: "public-webrtc",
-    otherLinks: [
-      {
-        key: "Participate",
-        data: [
-          {
-            value: "Mailing list",
-            href: "https://lists.w3.org/Archives/Public/public-webrtc/"
-          }
-        ]
-      }
-    ],
-    localBiblio: {
-      "IANA-STUN-6": {
-        "title": "STUN Error Codes",
-        "href": "https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6",
-        "publisher": "IANA"
-      },
-      "CRYPTEX": {
-	"aliasOf": "RFC9335"
-      },
-      "RTP-EXT-CAPTURE-TIME": {
-	"title": "RTP Header Extension for Absolute Capture Time",
-	"publisher": "WebRTC Project",
-	href: "https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time",
-	"status": "Experimental RTP Header Extension"
-      }
+  "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "infra", "dom"],
+  "specStatus": "ED",
+  editors: [
+    //              { name: "Your Name", url: "http://example.org/",
+    //                company: "Your Company", companyURL: "http://example.com/" },
+    {
+      name: "Bernard Aboba", company: "Microsoft Corporation",
+      w3cid: "65611"
     }
+  ],
+  formerEditors: [
+    { name: "Henrik Boström", company: "Google", w3cid: "96936", retiredDate: "2021-02-01" }
+  ],
+  authors: [
+  ],
+  wgPublicList: "public-webrtc",
+  otherLinks: [
+    {
+      key: "Participate",
+      data: [
+        {
+          value: "Mailing list",
+          href: "https://lists.w3.org/Archives/Public/public-webrtc/"
+        }
+      ]
+    }
+  ],
+  localBiblio: {
+    "IANA-STUN-6": {
+      "title": "STUN Error Codes",
+      "href": "https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6",
+      "publisher": "IANA"
+    },
+    "CRYPTEX": {
+      "aliasOf": "RFC9335"
+    },
+    "RTP-EXT-CAPTURE-TIME": {
+      "title": "RTP Header Extension for Absolute Capture Time",
+      "publisher": "WebRTC Project",
+      href: "https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time",
+      "status": "Experimental RTP Header Extension"
+    }
+  },
+  "xref": ["webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "mediacapture-extensions"]
 }

--- a/webrtc-extensions.js
+++ b/webrtc-extensions.js
@@ -1,52 +1,50 @@
 var respecConfig = {
-  "group": "webrtc",
-  github: {
-    repoURL: "https://github.com/w3c/webrtc-extensions/",
-    branch: "main"
-  },
+   "group": "webrtc",
+    github: {
+      repoURL: "https://github.com/w3c/webrtc-extensions/",
+      branch: "main"
+    },
   latestVersion: null,
-  "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "infra", "dom"],
-  "specStatus": "ED",
-  editors: [
-    //              { name: "Your Name", url: "http://example.org/",
-    //                company: "Your Company", companyURL: "http://example.com/" },
-    {
-      name: "Bernard Aboba", company: "Microsoft Corporation",
-      w3cid: "65611"
+    "xref": ["html", "webidl", "webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "infra", "dom"],
+    "specStatus": "ED",
+    editors:  [
+      //              { name: "Your Name", url: "http://example.org/",
+      //                company: "Your Company", companyURL: "http://example.com/" },
+      { name: "Bernard Aboba", company: "Microsoft Corporation",
+        w3cid: "65611"
+      }
+    ],
+    formerEditors: [
+      { name: "Henrik Boström", company: "Google", w3cid: "96936", retiredDate: "2021-02-01" }
+    ],
+    authors: [
+    ],
+    wgPublicList: "public-webrtc",
+    otherLinks: [
+      {
+        key: "Participate",
+        data: [
+          {
+            value: "Mailing list",
+            href: "https://lists.w3.org/Archives/Public/public-webrtc/"
+          }
+        ]
+      }
+    ],
+    localBiblio: {
+      "IANA-STUN-6": {
+        "title": "STUN Error Codes",
+        "href": "https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6",
+        "publisher": "IANA"
+      },
+      "CRYPTEX": {
+	"aliasOf": "RFC9335"
+      },
+      "RTP-EXT-CAPTURE-TIME": {
+	"title": "RTP Header Extension for Absolute Capture Time",
+	"publisher": "WebRTC Project",
+	href: "https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time",
+	"status": "Experimental RTP Header Extension"
+      }
     }
-  ],
-  formerEditors: [
-    { name: "Henrik Boström", company: "Google", w3cid: "96936", retiredDate: "2021-02-01" }
-  ],
-  authors: [
-  ],
-  wgPublicList: "public-webrtc",
-  otherLinks: [
-    {
-      key: "Participate",
-      data: [
-        {
-          value: "Mailing list",
-          href: "https://lists.w3.org/Archives/Public/public-webrtc/"
-        }
-      ]
-    }
-  ],
-  localBiblio: {
-    "IANA-STUN-6": {
-      "title": "STUN Error Codes",
-      "href": "https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6",
-      "publisher": "IANA"
-    },
-    "CRYPTEX": {
-      "aliasOf": "RFC9335"
-    },
-    "RTP-EXT-CAPTURE-TIME": {
-      "title": "RTP Header Extension for Absolute Capture Time",
-      "publisher": "WebRTC Project",
-      href: "https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time",
-      "status": "Experimental RTP Header Extension"
-    }
-  },
-  "xref": ["webrtc", "hr-time", "mediacapture-streams", "webrtc-stats", "mediacapture-extensions"]
 }


### PR DESCRIPTION
- **add WebRTC-specific interactions with capture/receive/RTP timestamps**
- **Rebase and update**
- **Fix some style stuff & undo webrtc-extensions.js changes.**
- **Address reviewer comments. Use SHOULD/MUST instead of is. Remove informative as things should be observable.**
- **Offline review with henbos@: removed ambiguous text.**
- **Address review changes**


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/233.html" title="Last updated on May 8, 2025, 12:43 PM UTC (4adaacc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/233/64141e2...4adaacc.html" title="Last updated on May 8, 2025, 12:43 PM UTC (4adaacc)">Diff</a>