### PR TITLE
Allow discarding Illegal header extensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,6 +215,10 @@ partial interface RTCRtpTransceiver {
                   view.</p>
                 </li>
                 <li>
+                  <p>If this extension cannot be used because of other options
+                    negotiated in the answer, set <var>answeredDirection</var>
+                    to {{RTCRtpTransceiverDirection/"stopped"}}.</p>
+                <li>
                   <p>Set
                   <var>extension</var>.{{RTCRtpHeaderExtensionCapability/direction}}
                   to <var>answeredDirection</var>.</p>


### PR DESCRIPTION
Fixes #239


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/240.html" title="Last updated on Sep 18, 2025, 1:04 PM UTC (532de44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/240/2146f80...532de44.html" title="Last updated on Sep 18, 2025, 1:04 PM UTC (532de44)">Diff</a>