### PR TITLE
Always negotiate datachannels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1525,6 +1525,20 @@ partial interface RTCRtpTransceiver {
         </dl>
       </section>
     </section>
+    <section id="always-negotiating-datachannels-negotiationneeded-extensions">
+      <h3>
+        Modifications to existing procedures
+      </h3>
+      <p>
+        In the steps to call the {{RTCPeerConnection/createDataChannel()}} method replace
+        "If channel is the first RTCDataChannel created on connection
+        update the negotiation-needed flag for connection"
+        with
+        "If channel is the first RTCDataChannel created on connection 
+        and {{RTCPeerConnection/[[SctpTransport]]}} is null
+        update the negotiation-needed flag for connection".
+      </p>
+    </section>
     <section id="always-negotiating-datachannels-interface-extensions">
       <h3>
         JSEP modifications

--- a/index.html
+++ b/index.html
@@ -1494,6 +1494,58 @@ partial interface RTCRtpTransceiver {
       </p>
     </section>
   </section>
+  <section id="always-negotiating-datachannels">
+    <h2>Always negotiating data channels</h2>
+    <section id="always-negotiating-datachannels-configuration">
+      <h3>
+        {{RTCConfiguration}} extensions
+      </h3>
+      <p>
+        {{RTCConfiguration/alwaysNegotiateDataChannels}} defines a way for the application
+        to negotiate data channels in the SDP offer before creating a datachannel.
+      </p>
+      <pre class="idl">partial dictionary RTCConfiguration {
+    boolean alwaysNegotiateDataChannels = false;
+};</pre>
+      <section>
+        <h2>
+          Dictionary {{RTCConfiguration}} Members
+        </h2>
+        <dl data-link-for="RTCConfiguration" data-dfn-for="RTCConfiguration" class="dictionary-members">
+          <dt>
+            <dfn data-idl="">alwaysNegotiateDataChannels</dfn> of type <span class="idlMemberType">boolean</span>
+          </dt>
+          <dd>
+            <p>
+            Specifies whether the application prefers to always negotiate data channels in the initial SDP offer.
+            </p>
+          </dd>
+        </dl>
+      </section>
+    </section>
+    <section id="always-negotiating-datachannels-interface-extensions">
+      <h3>
+        JSEP modifications
+      </h3>
+      <p>
+        In the PeerConnection's Constructor in [[RTCWEB-JSEP]] section 4.1.1, add
+        "The application can specify whether it prefers to always negotiate data channels"</li>
+      </p>
+      <p>
+        In the algorithms for generating initial offers in [[RTCWEB-JSEP]] section 5.2.1, insert
+        "If the application prefers to always negotiate data channels, a m=section MUST be generated for data with fields set as described below."
+        before
+        "An m= section is generated for each RtpTransceiver that has been added to the PeerConnection, [...]".
+      </p>
+      <p>
+        In the algorithms for generating initial offers in [[RTCWEB-JSEP]] section 5.2.1,
+        replace 
+        "Lastly, if a data channel has been created, a m= section MUST be generated for data"
+        with
+        "Lastly, if a data channel has been created and no m=section has been generated for data, a m= section MUST be generated for data".
+      </p>
+    </section>
+  </section>
   <section class="informative">
     <h2>Event summary</h2>
     <p>

--- a/index.html
+++ b/index.html
@@ -1503,6 +1503,8 @@ partial interface RTCRtpTransceiver {
       <p>
         {{RTCConfiguration/alwaysNegotiateDataChannels}} defines a way for the application
         to negotiate data channels in the SDP offer before creating a datachannel.
+        This also negotiates the data m= section before any audio or video m sections and
+        uses it as the "offerer-tagged m= section" for [[BUNDLE]].
       </p>
       <pre class="idl">partial dictionary RTCConfiguration {
     boolean alwaysNegotiateDataChannels = false;


### PR DESCRIPTION
extending JSEP rules to negotiate datachannels before createDataChannel and negotiate them as the first m-line in the SDP.

```
const pc = new RTCPeerConnection({alwaysNegotiateDataChannels: true});
pc.addTransceiver('audio');
await offer = pc.createOffer();
// assert that the first m= line is m=application
```

JSEP issue: https://github.com/rtcweb-wg/jsep/issues/1039

Fixes #241


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-extensions/pull/242.html" title="Last updated on Oct 19, 2025, 9:29 AM UTC (7f5bdb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/242/2146f80...fippo:7f5bdb5.html" title="Last updated on Oct 19, 2025, 9:29 AM UTC (7f5bdb5)">Diff</a>