### PR TITLE
Add onssrcchange/oncsrcchange events to RTCRtpReceiver

### DIFF
--- a/index.html
+++ b/index.html
@@ -1468,36 +1468,46 @@ partial interface RTCRtpTransceiver {
   attribute EventHandler oncsrcchange;
 };</pre>
     <p>
-      Whenever the {{RTCRtpContributingSource/source}} identifier is updated based on the last decoded frame,
-      the [= user agent =] MUST [= queue a task =] to [= fire an event =] named {{RTCRtpReceiver/ssrcchange}}
-      if the SSRC changed and an event named {{RTCRtpReceiver/csrcchange}} if the CSRC changed. If both
-      identifiers are changed based on the same decoded frame, both events fire in the same queued task. This
-      ensures that both SSRC and CSRC information is exposed to the app at the same time.
+      Whenever the {{RTCRtpContributingSource/source}} identifier(s) are updated based on the last decoded
+      frame as defined <a data-cite="WEBRTC#dom-rtcrtpcontributingsource">here</a>, the [= user agent =]
+      MUST append the following steps to the end of the same [=queue a task|queued task=]:
     </p>
-      <h3>
-        Attributes
-      </h3>
-      <dl data-link-for="RTCRtpReceiver" data-dfn-for="RTCRtpReceiver" class="attributes">
-        <dt>
-          <dfn id="dom-rtptransceiver-onssrcchange">onssrcchange</dfn> of type {{EventHandler}}
-        </dt>
-        <dd>
-          <p>
-            Fired when the {{RTCRtpContributingSource/source}} in {{RTCRtpReceiver/getSynchronizationSources()}}
-            changes, see above.
-          </p>
-        </dd>
-        <dt>
-          <dfn id="dom-rtptransceiver-oncsrcchange">oncsrcchange</dfn> of type {{EventHandler}}
-        </dt>
-        <dd>
-          <p>
-            Fired when the {{RTCRtpContributingSource/source}} in {{RTCRtpReceiver/getContributingSources()}}
-            changes, see above.
-          </p>
-        </dd>
-      </dl>
-    </section>
+    <ol>
+      <li>
+        <p>If the SSRC changed, [= fire an event =] named {{RTCRtpReceiver/ssrcchange}}.</p>
+      </li>
+      <li>
+        <p>If the CSRC changed, [= fire an event =] named {{RTCRtpReceiver/csrcchange}}.</p>
+      </li>
+    </ol>
+    <p class="note">
+      By firing the events after both the SSRC and CSRC information has been updated, both changes are
+      observable at the time that the first event fires.
+    </p>
+    <h3>
+      Attributes
+    </h3>
+    <dl data-link-for="RTCRtpReceiver" data-dfn-for="RTCRtpReceiver" class="attributes">
+      <dt>
+        <dfn id="dom-rtptransceiver-onssrcchange">onssrcchange</dfn> of type {{EventHandler}}
+      </dt>
+      <dd>
+        <p>
+          Fired when the {{RTCRtpContributingSource/source}} in {{RTCRtpReceiver/getSynchronizationSources()}}
+          changes, see above.
+        </p>
+      </dd>
+      <dt>
+        <dfn id="dom-rtptransceiver-oncsrcchange">oncsrcchange</dfn> of type {{EventHandler}}
+      </dt>
+      <dd>
+        <p>
+          Fired when the {{RTCRtpContributingSource/source}} in {{RTCRtpReceiver/getContributingSources()}}
+          changes, see above.
+        </p>
+      </dd>
+    </dl>
+  </section>
   <section id="disable-hardware">
     <h2>Disabling hardware acceleration</h2>
     <p>


### PR DESCRIPTION
Fixes #230.

To remind everyone, this was presented to the WG back in November of last year with resolution "RESOLUTION: Rough consensus on moving forward with events for csrc/ssrc changes, with concerns noted on related onunmute interop".
- WG notes: https://www.w3.org/2024/11/19-webrtc-minutes.html#c7d9
- Video recording: https://www.youtube.com/watch?v=eHjg9figxLk&t=1h11m50s

Regarding the onunmute discussion, Chrome has attempted to ship "remote track onunmute in response to RTP" but that had to be rolled back due to bugs detected at Stable, hopefully we can roll that forward again. I still believe that issue is largely tangential to this issue.

@koumiGoogle @taylor-b @jan-ivar


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-extensions/pull/243.html" title="Last updated on Oct 27, 2025, 9:38 AM UTC (5f6070c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/243/ccc0614...henbos:5f6070c.html" title="Last updated on Oct 27, 2025, 9:38 AM UTC (5f6070c)">Diff</a>