### PR TITLE
Modify header extension init to ignore "stopping" transceivers

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,8 @@ partial interface RTCRtpTransceiver {
         <li>
           <p>If transceivers of the same kind exist in the current PeerConnection,
             copy {{RTCRtpTransceiver/[[HeaderExtensionsToNegotiate]]}} from
-            the first such transceiver, in the order defined by the [=CollectTransceivers=] algorithm.
+            the first such transceiver, in the order defined by the [=CollectTransceivers=] algorithm,
+            where the {{RTCRtpTransceiver/[[Stopping]]}} internal slot is false.
             This ensures consistency across transceivers if they are added
             after initial negotiation.
           </p>


### PR DESCRIPTION
Fixes #249


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/pull/250.html" title="Last updated on Mar 12, 2026, 2:10 PM UTC (9abc823)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/250/9f2a0a1...9abc823.html" title="Last updated on Mar 12, 2026, 2:10 PM UTC (9abc823)">Diff</a>