### PR TITLE
Encoding complexity

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,13 +390,26 @@ partial interface RTCRtpTransceiver {
           </ol>
         </dd>
       </dl>
-    </section>
-  </section>
-  <section id="rtcrtpencodingparameters">
-    <h3>
-      RTCRtpEncodingParameters extensions
-    </h3>
-    <p>
+    \
+        </section>
+      </section>
+      <section id="rtcencodingcomplexity">
+        <h3>
+          The {{RTCEncodingComplexity}} enum.
+        </h3>
+        <pre class="idl">enum RTCEncodingComplexity {
+        "minimum",
+        "low",
+        "normal",
+        "high",
+        "very-high",
+        "maximum"
+    };</pre>
+      </section>
+      <section id="rtcrtpencodingparameters">
+        <h3>
+          RTCRtpEncodingParameters extensions
+        </h3>
       The {{RTCRtpEncodingParameters}} dictionary is defined in
       [[WEBRTC]]. This document extends that dictionary with
       additional members to control audio packetization.
@@ -405,6 +418,7 @@ partial interface RTCRtpTransceiver {
     RTCResolutionRestriction scaleResolutionDownTo;
     unsigned long            ptime;
     boolean                  adaptivePtime = false;
+    RTCEncodingComplexity    encodingComplexity;
 };</pre>
     <section id="rtcrtpencodingparameters-attributes">
       <h2>Dictionary {{RTCRtpEncodingParameters}} Members</h2>
@@ -469,6 +483,22 @@ partial interface RTCRtpTransceiver {
           of increased latency. Changing the frame length dynamically
           allows the <a>user agent</a> to adapt its bandwidth allocation strategy
           based on the current network conditions.</p>
+        </dd>
+        <dt>
+          <dfn data-idl>encodingComplexity</dfn> of type <span class="idlMemberType">{{RTCEncodingComplexity}}</span>
+        </dt>
+        <dd>
+          <p>Indicates the desired complexity for this encoding. The user agent MAY use this as a hint to select encoder settings to achieve the desired complexity. Higher complexity values are expected to result in higher quality at the cost of higher CPU usage and power consumption. This feature is implemented on a best-effort basis, as not all encoder implementations support this, and others may only support a subset of the complexity settings. Even if an encoder supports a given complexity setting, the user agent MAY choose to use a different one, for example, selecting a lower complexity if the encoder is not meeting real-time deadlines. The actual encoding complexity used MAY also change dynamically based on system conditions.</p>
+          <p>Assuming that {{RTCEncodingComplexity/"normal"}} maps to the encoder's default real-time speed setting, the expected relative change in encoding time for other values are approximately:</p>
+          <ul>
+            <li>{{RTCEncodingComplexity/"maximum"}}: The highest complexity setting compliant with real-time constraints.</li>
+            <li>{{RTCEncodingComplexity/"very-high"}}: +50%</li>
+            <li>{{RTCEncodingComplexity/"high"}}: +15%</li>
+            <li>{{RTCEncodingComplexity/"normal"}}: +/- 0%</li>
+            <li>{{RTCEncodingComplexity/"low"}}: -15%</li>
+            <li>{{RTCEncodingComplexity/"minimum"}}: As low as possible</li>
+          </ul>
+          <p class="note">The user agent MAY choose to alternate between complexity levels to achieve an intermediate effect. This can be particularly useful in scenarios like temporal layering, where applying higher complexity to the base layer frames can yield significant quality benefits.</p>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -390,14 +390,18 @@ partial interface RTCRtpTransceiver {
           </ol>
         </dd>
       </dl>
-    \
-        </section>
-      </section>
-      <section id="rtcencodingcomplexity">
-        <h3>
-          The {{RTCEncodingComplexity}} enum.
-        </h3>
-        <pre class="idl">enum RTCEncodingComplexity {
+    </section>
+  </section>
+  <section id="rtcrtpencodingparameters">
+    <h3>
+      RTCRtpEncodingParameters extensions
+    </h3>
+    <p>
+      The {{RTCRtpEncodingParameters}} dictionary is defined in
+      [[WEBRTC]]. This document extends that dictionary with
+      additional members to control audio packetization.
+    </p>
+    <pre class="idl">enum RTCEncodingComplexity {
         "minimum",
         "low",
         "normal",
@@ -405,15 +409,6 @@ partial interface RTCRtpTransceiver {
         "very-high",
         "maximum"
     };</pre>
-      </section>
-      <section id="rtcrtpencodingparameters">
-        <h3>
-          RTCRtpEncodingParameters extensions
-        </h3>
-      The {{RTCRtpEncodingParameters}} dictionary is defined in
-      [[WEBRTC]]. This document extends that dictionary with
-      additional members to control audio packetization.
-    </p>
     <pre class="idl">partial dictionary RTCRtpEncodingParameters {
     RTCResolutionRestriction scaleResolutionDownTo;
     unsigned long            ptime;


### PR DESCRIPTION
This introduces a new enum `RTCEncodingComplexity` and adds an `encodingComplexity` member to `RTCRtpEncodingParameters` to allow applications to hint at the desired trade-off between quality and CPU/power consumption for an encoding.

Fixes #191


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sprangerik/webrtc-extensions/pull/252.html" title="Last updated on May 8, 2026, 2:38 PM UTC (a505af5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/252/9f2a0a1...sprangerik:a505af5.html" title="Last updated on May 8, 2026, 2:38 PM UTC (a505af5)">Diff</a>