### PR TITLE
alwaysNegotiateDataChannels: disallow setConfiguration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1625,9 +1625,19 @@ partial interface RTCRtpTransceiver {
         "If channel is the first RTCDataChannel created on connection
         update the negotiation-needed flag for connection"
         with
-        "If channel is the first RTCDataChannel created on connection 
+        "If channel is the first RTCDataChannel created on connection
         and {{RTCPeerConnection/[[SctpTransport]]}} is null
         update the negotiation-needed flag for connection".
+      </p>
+      <p>
+        {{RTCConfiguration/alwaysNegotiateDataChannels}} can only be set when constructing the
+        {{RTCPeerConnection}} and MUST NOT be changed afterwards.
+        In the <a data-cite="WEBRTC#set-the-configuration">set the configuration</a> algorithm,
+        add a step after the step saying
+        "If the value of configuration.rtcpMuxPolicy differs from oldConfig.rtcpMuxPolicy, then fail."
+        saying
+        "If the value of configuration.{{RTCConfiguration/alwaysNegotiateDataChannels}} differs from
+        oldConfig.{{RTCConfiguration/alwaysNegotiateDataChannels}}, then fail."
       </p>
     </section>
     <section id="always-negotiating-datachannels-interface-extensions">
@@ -1650,6 +1660,13 @@ partial interface RTCRtpTransceiver {
         "Lastly, if a data channel has been created, a m= section MUST be generated for data"
         with
         "Lastly, if a data channel has been created and no m=section has been generated for data, a m= section MUST be generated for data".
+      </p>
+      <p>
+        In setConfiguration in [[RTCWEB-JSEP]] section 4.1.18, replace
+        "The bundle and RTCP-multiplexing policies MUST NOT be changed after the construction of the PeerConnection."
+        with
+        "The bundle policy, the RTCP-multiplexing policy and the preference to always negotiate data channels
+        MUST NOT be changed after the construction of the PeerConnection."
       </p>
     </section>
   </section>


### PR DESCRIPTION
which can cause trouble and is not worth it.

@docfaraday does that work? (apart from the question whether we can modify an RFC ;-))


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-extensions/pull/254.html" title="Last updated on Aug 3, 2026, 4:19 PM UTC (6bacf1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/254/fb2c4cd...fippo:6bacf1c.html" title="Last updated on Aug 3, 2026, 4:19 PM UTC (6bacf1c)">Diff</a>