### PR TITLE
always-nego: not just the initial offer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1610,7 +1610,7 @@ partial interface RTCRtpTransceiver {
           </dt>
           <dd>
             <p>
-            Specifies whether the application prefers to always negotiate data channels in the initial SDP offer.
+            Specifies whether the application prefers to always negotiate data channels in the SDP offer.
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
*almost* editorial but has an assertable property.

When configured also negotiate it after
  SRD(offer, audio-only)
  SLD()
  createOffer() -> audio,data


As code:
```
const pc = new RTCPeerConnection({alwaysNegotiateDataChannels: true});
await pc.setRemoteDescription({type: 'offer', sdp: 'v=0\no=- 0 3 IN IP4 127.0.0.1\ns=-\nt=0 0\na=fingerprint:sha-256 A7:24:72:CA:6E:02:55:39:BA:66:DF:6E:CC:4C:D8:B0:1A:BF:1A:56:65:7D:F4:03:AD:7E:77:43:2A:29:EC:93\na=ice-ufrag:6HHHdzzeIhkE0CKj\na=ice-pwd:XYDGVpfvklQIEnZ6YnyLsAew\nm=audio 9 RTP/SAVPF 111\nc=IN IP4 0.0.0.0\na=rtcp-mux\na=sendonly\na=mid:audio\na=rtpmap:111 opus/48000/2\na=setup:actpass\n'});
await pc.setLocalDescription();
offer = await pc.createOffer()
console.log(offer.sdp.split('\r\n').filter(l => l.startsWith('m=')))
```
should log `['m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126', 'm=application 9 UDP/DTLS/SCTP webrtc-datachannel']


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-extensions/pull/257.html" title="Last updated on Aug 20, 2026, 10:23 AM UTC (936fbf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-extensions/257/3ff864b...fippo:936fbf1.html" title="Last updated on Aug 20, 2026, 10:23 AM UTC (936fbf1)">Diff</a>